### PR TITLE
Temporary fix for PythonLib

### DIFF
--- a/pythonlib/nestgpu.py
+++ b/pythonlib/nestgpu.py
@@ -12,7 +12,9 @@ print(' of spiking neurons')
 print('Homepage: https://github.com/golosio/NeuronGPU') 
 print('-----------------------------------------------------------------')
 
-lib_path="/usr/local/lib/libnestgpu.so"
+lib_dir=os.environ["NEST_GPU"]
+lib_path=lib_dir + "/lib/libnestgpu.so"
+#lib_path="/usr/local/lib/libnestgpu.so"
 _nestgpu=ctypes.CDLL(lib_path)
 
 c_float_p = ctypes.POINTER(ctypes.c_float)


### PR DESCRIPTION
When installing Nest GPU a custom python library is generated from a template file. However the path stored in the generated library is incorrect for cluster installations. A quick fix is provided in this change but we should think about a more general and long term solution.