### PR TITLE
Remove unused and almost empty tutorials file from documentation

### DIFF
--- a/doc/tutorials/index.rst
+++ b/doc/tutorials/index.rst
@@ -1,4 +1,0 @@
-Tutorials
-=========
-
-Work in progress...


### PR DESCRIPTION
Right now, building the documentation gives the warning:
`.../nest-gpu/doc/tutorials/index.rst: WARNING: document isn't included in any toctree`
As long as we do not have tutorials or guides, I suggest to remove this almost empty file from the documentation.