### PR TITLE
Model time print & NEST GPU kernel update

### DIFF
--- a/python/Potjans_2014/network.py
+++ b/python/Potjans_2014/network.py
@@ -289,6 +289,7 @@ class Network:
 
         master_seed = self.sim_dict['master_seed']
         ngpu.SetRandomSeed(master_seed)
+        ngpu.SetKernelStatus({'print_time': self.sim_dict['print_time']})
         self.sim_resolution = self.sim_dict['sim_resolution']
 
     def __create_neuronal_populations(self):

--- a/python/Potjans_2014/sim_params.py
+++ b/python/Potjans_2014/sim_params.py
@@ -54,4 +54,4 @@ sim_dict = {
     'overwrite_files': True,
     # print the time progress. This should only be used when the simulation
     # is run on a local machine.
-    'print_time': True}
+    'print_time': False}

--- a/python/Potjans_2014/sim_params.py
+++ b/python/Potjans_2014/sim_params.py
@@ -32,7 +32,7 @@ sim_dict = {
     # The full simulation time is the sum of a presimulation time and the main
     # simulation time.
     # presimulation time (in ms)
-    't_presim': 1000.0,
+    't_presim': 500.0,
     # simulation time (in ms)
     't_sim': 10000.0,
     # resolution of the simulation (in ms)

--- a/python/Potjans_2014/sim_params.templ
+++ b/python/Potjans_2014/sim_params.templ
@@ -54,4 +54,4 @@ sim_dict = {
     'overwrite_files': True,
     # print the time progress. This should only be used when the simulation
     # is run on a local machine.
-    'print_time': True}
+    'print_time': False}

--- a/python/Potjans_2014/sim_params.templ
+++ b/python/Potjans_2014/sim_params.templ
@@ -32,7 +32,7 @@ sim_dict = {
     # The full simulation time is the sum of a presimulation time and the main
     # simulation time.
     # presimulation time (in ms)
-    't_presim': 1000.0,
+    't_presim': 500.0,
     # simulation time (in ms)
     't_sim': 10000.0,
     # resolution of the simulation (in ms)

--- a/python/Potjans_2014/sim_params_norec.py
+++ b/python/Potjans_2014/sim_params_norec.py
@@ -32,7 +32,7 @@ sim_dict = {
     # The full simulation time is the sum of a presimulation time and the main
     # simulation time.
     # presimulation time (in ms)
-    't_presim': 0.1,
+    't_presim': 500.0,
     # simulation time (in ms)
     't_sim': 10000.0,
     # resolution of the simulation (in ms)
@@ -54,4 +54,4 @@ sim_dict = {
     'overwrite_files': True,
     # print the time progress. This should only be used when the simulation
     # is run on a local machine.
-    'print_time': True}
+    'print_time': False}

--- a/python/Potjans_2014/sim_params_norec.templ
+++ b/python/Potjans_2014/sim_params_norec.templ
@@ -54,4 +54,4 @@ sim_dict = {
     'overwrite_files': True,
     # print the time progress. This should only be used when the simulation
     # is run on a local machine.
-    'print_time': True}
+    'print_time': False}

--- a/python/Potjans_2014/sim_params_norec.templ
+++ b/python/Potjans_2014/sim_params_norec.templ
@@ -32,7 +32,7 @@ sim_dict = {
     # The full simulation time is the sum of a presimulation time and the main
     # simulation time.
     # presimulation time (in ms)
-    't_presim': 0.1,
+    't_presim': 500.0,
     # simulation time (in ms)
     't_sim': 10000.0,
     # resolution of the simulation (in ms)

--- a/python/Potjans_2014_hc/network.py
+++ b/python/Potjans_2014_hc/network.py
@@ -289,6 +289,7 @@ class Network:
 
         master_seed = self.sim_dict['master_seed']
         ngpu.SetRandomSeed(master_seed)
+        ngpu.SetKernelStatus({'print_time': self.sim_dict['print_time']})
         self.sim_resolution = self.sim_dict['sim_resolution']
 
     def __create_neuronal_populations(self):

--- a/python/Potjans_2014_hc/sim_params.py
+++ b/python/Potjans_2014_hc/sim_params.py
@@ -54,4 +54,4 @@ sim_dict = {
     'overwrite_files': True,
     # print the time progress. This should only be used when the simulation
     # is run on a local machine.
-    'print_time': True}
+    'print_time': False}

--- a/python/Potjans_2014_hc/sim_params.templ
+++ b/python/Potjans_2014_hc/sim_params.templ
@@ -54,4 +54,4 @@ sim_dict = {
     'overwrite_files': True,
     # print the time progress. This should only be used when the simulation
     # is run on a local machine.
-    'print_time': True}
+    'print_time': False}

--- a/python/Potjans_2014_hc/sim_params_norec.py
+++ b/python/Potjans_2014_hc/sim_params_norec.py
@@ -54,4 +54,4 @@ sim_dict = {
     'overwrite_files': True,
     # print the time progress. This should only be used when the simulation
     # is run on a local machine.
-    'print_time': True}
+    'print_time': False}

--- a/python/Potjans_2014_s/network.py
+++ b/python/Potjans_2014_s/network.py
@@ -286,6 +286,7 @@ class Network:
 
         master_seed = self.sim_dict['master_seed']
         ngpu.SetRandomSeed(master_seed)
+        ngpu.SetKernelStatus({'print_time': self.sim_dict['print_time']})
         self.sim_resolution = self.sim_dict['sim_resolution']
 
     def __create_neuronal_populations(self):

--- a/python/Potjans_2014_s/sim_params.py
+++ b/python/Potjans_2014_s/sim_params.py
@@ -54,4 +54,4 @@ sim_dict = {
     'overwrite_files': True,
     # print the time progress. This should only be used when the simulation
     # is run on a local machine.
-    'print_time': True}
+    'print_time': False}

--- a/python/Potjans_2014_s/sim_params.templ
+++ b/python/Potjans_2014_s/sim_params.templ
@@ -54,4 +54,4 @@ sim_dict = {
     'overwrite_files': True,
     # print the time progress. This should only be used when the simulation
     # is run on a local machine.
-    'print_time': True}
+    'print_time': False}

--- a/python/Potjans_2014_s/sim_params_norec.py
+++ b/python/Potjans_2014_s/sim_params_norec.py
@@ -54,4 +54,4 @@ sim_dict = {
     'overwrite_files': True,
     # print the time progress. This should only be used when the simulation
     # is run on a local machine.
-    'print_time': True}
+    'print_time': False}

--- a/src/nestgpu.cu
+++ b/src/nestgpu.cu
@@ -1701,12 +1701,6 @@ int NESTGPU::ConnectRemoteNodes()
 }
 
 
-
-
-
-
-
-
 int NESTGPU::GetNBoolParam()
 {
   return N_KERNEL_BOOL_PARAM;

--- a/src/nestgpu.cu
+++ b/src/nestgpu.cu
@@ -80,6 +80,11 @@ enum KernelIntParamIndexes {
   N_KERNEL_INT_PARAM
 };
 
+enum KernelBoolParamIndexes {
+  i_print_time,
+  N_KERNEL_BOOL_PARAM
+};
+
 const std::string kernel_float_param_name[N_KERNEL_FLOAT_PARAM] = {
   "time_resolution",
   "max_spike_num_fact",
@@ -91,6 +96,10 @@ const std::string kernel_int_param_name[N_KERNEL_INT_PARAM] = {
   "verbosity_level",
   "max_spike_buffer_size",
   "remote_spike_height_flag"
+};
+
+const std::string kernel_bool_param_name[N_KERNEL_BOOL_PARAM] = {
+  "print_time"
 };
 
 NESTGPU::NESTGPU()
@@ -123,6 +132,7 @@ NESTGPU::NESTGPU()
   on_exception_ = ON_EXCEPTION_EXIT;
 
   verbosity_level_ = 4;
+  print_time_ = false;
   
   mpi_flag_ = false;
 #ifdef HAVE_MPI
@@ -349,8 +359,8 @@ int NESTGPU::Simulate()
   StartSimulation();
   
   for (long long it=0; it<Nt_; it++) {
-    if (it%100==0 && verbosity_level_>=2) {
-      printf("%.3lf\n", neural_time_);
+    if (it%100==0 && verbosity_level_>=2 && print_time_==true) {
+      printf("\r[%.2lf %%] Model time: %.3lf", 100.0*(neural_time_-neur_t0_)/sim_time_, neural_time_);
     }
     SimulationStep();
   }
@@ -389,8 +399,8 @@ int NESTGPU::StartSimulation()
 
 int NESTGPU::EndSimulation()
 {
-  if (verbosity_level_>=2) {
-    printf("%.3lf\n", neural_time_);
+  if (verbosity_level_>=2  && print_time_==true) {
+    printf("\r[%.2lf %%] Model time: %.3lf", 100.0*(neural_time_-neur_t0_)/sim_time_, neural_time_);
   }
 #ifdef HAVE_MPI                                        
   if (mpi_flag_) {
@@ -1689,6 +1699,80 @@ int NESTGPU::ConnectRemoteNodes()
   
   return 0;
 }
+
+
+
+
+
+
+
+
+int NESTGPU::GetNBoolParam()
+{
+  return N_KERNEL_BOOL_PARAM;
+}
+
+std::vector<std::string> NESTGPU::GetBoolParamNames()
+{
+  std::vector<std::string> param_name_vect;
+  for (int i=0; i<N_KERNEL_BOOL_PARAM; i++) {
+    param_name_vect.push_back(kernel_bool_param_name[i]);
+  }
+  
+  return param_name_vect;
+}
+
+bool NESTGPU::IsBoolParam(std::string param_name)
+{
+  int i_param;
+  for (i_param=0; i_param<N_KERNEL_BOOL_PARAM; i_param++) {
+    if (param_name == kernel_bool_param_name[i_param]) return true;
+  }
+  return false;
+}
+
+int NESTGPU::GetBoolParamIdx(std::string param_name)
+{
+  int i_param;
+  for (i_param=0; i_param<N_KERNEL_BOOL_PARAM; i_param++) {
+    if (param_name == kernel_bool_param_name[i_param]) break;
+  }
+  if (i_param == N_KERNEL_BOOL_PARAM) {
+    throw ngpu_exception(std::string("Unrecognized kernel boolean parameter ")
+			 + param_name);
+  }
+  
+  return i_param;
+}
+
+bool NESTGPU::GetBoolParam(std::string param_name)
+{
+  int i_param =  GetBoolParamIdx(param_name);
+  switch (i_param) {
+  case i_print_time:
+    return print_time_;
+  default:
+    throw ngpu_exception(std::string("Unrecognized kernel boolean parameter ")
+			 + param_name);
+  }
+}
+
+int NESTGPU::SetBoolParam(std::string param_name, bool val)
+{
+  int i_param =  GetBoolParamIdx(param_name);
+
+  switch (i_param) {
+  case i_time_resolution:
+    print_time_ = val;
+    break;
+  default:
+    throw ngpu_exception(std::string("Unrecognized kernel boolean parameter ")
+			 + param_name);
+  }
+  
+  return 0;
+}
+
 
 int NESTGPU::GetNFloatParam()
 {

--- a/src/nestgpu.cu
+++ b/src/nestgpu.cu
@@ -360,7 +360,7 @@ int NESTGPU::Simulate()
   
   for (long long it=0; it<Nt_; it++) {
     if (it%100==0 && verbosity_level_>=2 && print_time_==true) {
-      printf("\r[%.2lf %%] Model time: %.3lf", 100.0*(neural_time_-neur_t0_)/sim_time_, neural_time_);
+      printf("\r[%.2lf %%] Model time: %.3lf ms", 100.0*(neural_time_-neur_t0_)/sim_time_, neural_time_);
     }
     SimulationStep();
   }
@@ -387,7 +387,7 @@ int NESTGPU::StartSimulation()
   }
   if (verbosity_level_>=1) {
     std::cout << MpiRankStr() << "Simulating ...\n";
-    printf("Neural activity simulation time: %.3lf\n", sim_time_);
+    printf("Neural activity simulation time: %.3lf ms\n", sim_time_);
   }
   
   neur_t0_ = neural_time_;
@@ -400,7 +400,7 @@ int NESTGPU::StartSimulation()
 int NESTGPU::EndSimulation()
 {
   if (verbosity_level_>=2  && print_time_==true) {
-    printf("\r[%.2lf %%] Model time: %.3lf", 100.0*(neural_time_-neur_t0_)/sim_time_, neural_time_);
+    printf("\r[%.2lf %%] Model time: %.3lf ms", 100.0*(neural_time_-neur_t0_)/sim_time_, neural_time_);
   }
 #ifdef HAVE_MPI                                        
   if (mpi_flag_) {

--- a/src/nestgpu.h
+++ b/src/nestgpu.h
@@ -151,6 +151,7 @@ class NESTGPU
   int on_exception_;
 
   int verbosity_level_;
+  bool print_time_;
 
   std::vector<RemoteConnection> remote_connection_vect_;
   std::vector<int> ext_neuron_input_spike_node_;
@@ -286,8 +287,21 @@ class NESTGPU
     return 0;
   }
 
+  inline int SetPrintTime(bool print_time) {
+    print_time_ = print_time;
+    return 0;
+  }
+
+
   int SetMaxSpikeBufferSize(int max_size);
   int GetMaxSpikeBufferSize();
+
+  int GetNBoolParam();
+  std::vector<std::string> GetBoolParamNames();
+  bool IsBoolParam(std::string param_name);
+  int GetBoolParamIdx(std::string param_name);
+  bool GetBoolParam(std::string param_name);
+  int SetBoolParam(std::string param_name, bool val);
 
   int GetNFloatParam();
   std::vector<std::string> GetFloatParamNames();

--- a/src/nestgpu_C.cpp
+++ b/src/nestgpu_C.cpp
@@ -1012,6 +1012,62 @@ extern "C" {
   } END_ERR_PROP return ret; }
 
 
+  int NESTGPU_GetNBoolParam()
+  { int ret = 0; BEGIN_ERR_PROP {
+    ret = NESTGPU_instance->GetNBoolParam();
+  } END_ERR_PROP return ret; }
+
+  
+  char **NESTGPU_GetBoolParamNames()
+  { char **ret = NULL; BEGIN_ERR_PROP {
+    std::vector<std::string> name_vect =
+      NESTGPU_instance->GetBoolParamNames();
+    char **name_array = (char**)malloc(name_vect.size()
+				       *sizeof(char*));
+    for (unsigned int i=0; i<name_vect.size(); i++) {
+      char *param_name = (char*)malloc((name_vect[i].length() + 1)
+				       *sizeof(char));
+      
+      strcpy(param_name, name_vect[i].c_str());
+      name_array[i] = param_name;
+    }
+    ret = name_array;
+    
+  } END_ERR_PROP return ret; }
+
+  
+  int NESTGPU_IsBoolParam(char *param_name)
+  { int ret = 0; BEGIN_ERR_PROP {
+    std::string param_name_str = std::string(param_name);
+    
+    ret = NESTGPU_instance->IsBoolParam(param_name_str);
+  } END_ERR_PROP return ret; }
+
+  
+  int NESTGPU_GetBoolParamIdx(char *param_name)
+  { int ret = 0; BEGIN_ERR_PROP {
+    std::string param_name_str = std::string(param_name);
+    
+    ret = NESTGPU_instance->GetBoolParamIdx(param_name_str);
+  } END_ERR_PROP return ret; }
+
+  
+  bool NESTGPU_GetBoolParam(char *param_name)
+  { bool ret = true; BEGIN_ERR_PROP {
+    std::string param_name_str = std::string(param_name);
+    
+    ret = NESTGPU_instance->GetBoolParam(param_name_str);
+  } END_ERR_PROP return ret; }
+
+  
+  int NESTGPU_SetBoolParam(char *param_name, bool val)
+  { int ret = 0; BEGIN_ERR_PROP {
+    std::string param_name_str = std::string(param_name);
+    
+    ret = NESTGPU_instance->SetBoolParam(param_name_str, val);
+  } END_ERR_PROP return ret; }
+
+
   int NESTGPU_GetNFloatParam()
   { int ret = 0; BEGIN_ERR_PROP {
     ret = NESTGPU_instance->GetNFloatParam();

--- a/src/nestgpu_C.h
+++ b/src/nestgpu_C.h
@@ -311,6 +311,18 @@ extern "C" {
 
   float NESTGPU_GetNeuronGroupParam(int i_node, char *param_name);
 
+  int NESTGPU_GetNBoolParam();
+  
+  char **NESTGPU_GetBoolParamNames();
+  
+  int NESTGPU_IsBoolParam(char *param_name);
+  
+  int NESTGPU_GetBoolParamIdx(char *param_name);
+  
+  bool NESTGPU_GetBoolParam(char *param_name);
+  
+  int NESTGPU_SetBoolParam(char *param_name, bool val);
+
   int NESTGPU_GetNFloatParam();
   
   char **NESTGPU_GetFloatParamNames();


### PR DESCRIPTION
Changes introduced:
- added the possibility of having boolean entries for the NEST GPU kernel
- added the first boolean entry for the kernel, which is 'print_time' (default False, as in NEST). If False, there are no prints after any simulation step. If True, a line like the following is refreshed at the end of every simulation step, showing simulation advancement in percentage and the time simulated

[100.00 %] Model time: 500.000 ms

- adapted the cortical microcircuit model option 'print_time', which in the NEST GPU implementation was unused. Now the parameter 'print_time' sets its homologous in the NEST GPU kernel