### PR TITLE
Add Community section to documentation

### DIFF
--- a/doc/community.rst
+++ b/doc/community.rst
@@ -8,7 +8,7 @@ Issues and pull requests on GitHub
 
 On `<https://github.com/nest/nest-gpu>`_, you can submit
 
-* issues for reporting bugs and requesting features, and
+* issues for reporting bugs and requesting features
 * pull requests for contributing to the source code and the documentation.
 
 Mailing list

--- a/doc/community.rst
+++ b/doc/community.rst
@@ -1,0 +1,29 @@
+Community
+=========
+
+NEST GPU adopts the unified, community-centered workflow of NEST and encourages both users and developers to get in touch in the following ways:
+
+Issues and pull requests on GitHub
+##################################
+
+On `<https://github.com/nest/nest-gpu>`_, you can submit
+
+* issues for reporting bugs and requesting features, and
+* pull requests for contributing to the source code and the documentation.
+
+Mailing list
+############
+
+The NEST User Mailing List is intended to be a forum for questions on the usage of NEST, the exchange of code, and general discussions about NEST. NEST GPU-specific topics are equally welcome. The philosophy is that all users profit by sharing their experience. All NEST core developers are subscribed to this list and will participate in the discussions as far as time allows.
+
+By subscribing to the mailing list you will also get notified of all NEST-related events!
+
+Please find `here <https://nest-simulator.readthedocs.io/en/stable/contribute/mailing_list_guidelines.html>`_ the guidelines for contributing to the mailing list and information on how to access it.
+
+Open video conference
+#####################
+
+Every two weeks, we have an open video conference to discuss current issues and developments in NEST. We welcome users with questions regarding their implementations or issues they want help solving to join. This is an opportunity to have discussions in real time with developers.
+
+Information for dates and how to join can be found on the `GitHub wiki <https://github.com/nest/nest-simulator/wiki/Open-NEST-Developer-Video-Conference>`_.
+

--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -19,5 +19,6 @@ Table of Contents
    :maxdepth: 2
    :caption: Getting Involved
 
+   Community <community>
    Publications <publications>
 


### PR DESCRIPTION
Add information on issues and pull requests, the mailing list, and the open video conference to the documentation.

As discussed in the last open video conference, the general NEST channels such as the mailing list can also be used for questions regarding NEST GPU.