### PR TITLE
Change cudaMemcpy and cudaMemcpyToSymboal to Async where applicable

### DIFF
--- a/src/base_neuron.cu
+++ b/src/base_neuron.cu
@@ -244,7 +244,8 @@ int BaseNeuron::SetScalParam(int *i_neuron, int n_neuron,
   }
   int *d_i_neuron;
   gpuErrchk(cudaMalloc(&d_i_neuron, n_neuron*sizeof(int)));
-  gpuErrchk(cudaMemcpy(d_i_neuron, i_neuron, n_neuron*sizeof(int),
+  // Memcopy will be synchronized with BaseNeuronSetFloatPtArray kernel
+  gpuErrchk(cudaMemcpyAsync(d_i_neuron, i_neuron, n_neuron*sizeof(int),
 		       cudaMemcpyHostToDevice));
   float *param_pt = GetParamPt(0, param_name);
   BaseNeuronSetFloatPtArray<<<(n_neuron+1023)/1024, 1024>>>
@@ -302,7 +303,8 @@ int BaseNeuron::SetPortParam(int *i_neuron, int n_neuron,
   }
   int *d_i_neuron;
   gpuErrchk(cudaMalloc(&d_i_neuron, n_neuron*sizeof(int)));
-  gpuErrchk(cudaMemcpy(d_i_neuron, i_neuron, n_neuron*sizeof(int),
+  // Memcopy will be synchronized with BaseNeuronSetFloatPtArray kernel
+  gpuErrchk(cudaMemcpyAsync(d_i_neuron, i_neuron, n_neuron*sizeof(int),
 		       cudaMemcpyHostToDevice));
   for (int i_vect=0; i_vect<vect_size; i_vect++) {
     float *param_pt = GetParamPt(0, param_name, i_vect);
@@ -387,7 +389,8 @@ int BaseNeuron::SetIntVar(int *i_neuron, int n_neuron,
   }
   int *d_i_neuron;
   gpuErrchk(cudaMalloc(&d_i_neuron, n_neuron*sizeof(int)));
-  gpuErrchk(cudaMemcpy(d_i_neuron, i_neuron, n_neuron*sizeof(int),
+  // Memcopy will be synchronized with BaseNeuronSetIntPtArray kernel
+  gpuErrchk(cudaMemcpyAsync(d_i_neuron, i_neuron, n_neuron*sizeof(int),
 		       cudaMemcpyHostToDevice));
   int *var_pt = GetIntVarPt(0, var_name);
   BaseNeuronSetIntPtArray<<<(n_neuron+1023)/1024, 1024>>>
@@ -432,7 +435,8 @@ int BaseNeuron::SetScalVar(int *i_neuron, int n_neuron,
   }
   int *d_i_neuron;
   gpuErrchk(cudaMalloc(&d_i_neuron, n_neuron*sizeof(int)));
-  gpuErrchk(cudaMemcpy(d_i_neuron, i_neuron, n_neuron*sizeof(int),
+  // Memcopy will be synchronized with BaseNeuronSetFloatPtArray kernel
+  gpuErrchk(cudaMemcpyAsync(d_i_neuron, i_neuron, n_neuron*sizeof(int),
 		       cudaMemcpyHostToDevice));
   float *var_pt = GetVarPt(0, var_name);
   BaseNeuronSetFloatPtArray<<<(n_neuron+1023)/1024, 1024>>>
@@ -490,7 +494,8 @@ int BaseNeuron::SetPortVar(int *i_neuron, int n_neuron,
   }
   int *d_i_neuron;
   gpuErrchk(cudaMalloc(&d_i_neuron, n_neuron*sizeof(int)));
-  gpuErrchk(cudaMemcpy(d_i_neuron, i_neuron, n_neuron*sizeof(int),
+  // Memcopy will be synchronized with BaseNeuronSetFloatPtArray kernel
+  gpuErrchk(cudaMemcpyAsync(d_i_neuron, i_neuron, n_neuron*sizeof(int),
 		       cudaMemcpyHostToDevice));
   for (int i_vect=0; i_vect<vect_size; i_vect++) {
     float *var_pt = GetVarPt(0, var_name, i_vect);
@@ -568,7 +573,8 @@ float *BaseNeuron::GetScalParam(int *i_neuron, int n_neuron,
   }
   int *d_i_neuron;
   gpuErrchk(cudaMalloc(&d_i_neuron, n_neuron*sizeof(int)));
-  gpuErrchk(cudaMemcpy(d_i_neuron, i_neuron, n_neuron*sizeof(int),
+  // Memcopy will be synchronized with BaseNeuronGetFloatPtArray kernel
+  gpuErrchk(cudaMemcpyAsync(d_i_neuron, i_neuron, n_neuron*sizeof(int),
 		       cudaMemcpyHostToDevice));
   float *param_pt = GetParamPt(0, param_name);
 
@@ -632,7 +638,8 @@ float *BaseNeuron::GetPortParam(int *i_neuron, int n_neuron,
   }
   int *d_i_neuron;
   gpuErrchk(cudaMalloc(&d_i_neuron, n_neuron*sizeof(int)));
-  gpuErrchk(cudaMemcpy(d_i_neuron, i_neuron, n_neuron*sizeof(int),
+  // Memcopy will be synchronized with BaseNeuronGetFloatPtArray kernel
+  gpuErrchk(cudaMemcpyAsync(d_i_neuron, i_neuron, n_neuron*sizeof(int),
 		       cudaMemcpyHostToDevice));
 
   float *d_param_arr;
@@ -719,7 +726,8 @@ int *BaseNeuron::GetIntVar(int *i_neuron, int n_neuron,
   }
   int *d_i_neuron;
   gpuErrchk(cudaMalloc(&d_i_neuron, n_neuron*sizeof(int)));
-  gpuErrchk(cudaMemcpy(d_i_neuron, i_neuron, n_neuron*sizeof(int),
+  // Memcopy will be synchronized with BaseNeuronGetIntPtArray kernel
+  gpuErrchk(cudaMemcpyAsync(d_i_neuron, i_neuron, n_neuron*sizeof(int),
 		       cudaMemcpyHostToDevice));
   int *var_pt = GetIntVarPt(0, var_name);
 
@@ -780,7 +788,8 @@ float *BaseNeuron::GetScalVar(int *i_neuron, int n_neuron,
   }
   int *d_i_neuron;
   gpuErrchk(cudaMalloc(&d_i_neuron, n_neuron*sizeof(int)));
-  gpuErrchk(cudaMemcpy(d_i_neuron, i_neuron, n_neuron*sizeof(int),
+  // Memcopy will be synchronized with BaseNeuronGetFloatPtArray kernel
+  gpuErrchk(cudaMemcpyAsync(d_i_neuron, i_neuron, n_neuron*sizeof(int),
 		       cudaMemcpyHostToDevice));
   float *var_pt = GetVarPt(0, var_name);
 
@@ -844,7 +853,8 @@ float *BaseNeuron::GetPortVar(int *i_neuron, int n_neuron,
   }
   int *d_i_neuron;
   gpuErrchk(cudaMalloc(&d_i_neuron, n_neuron*sizeof(int)));
-  gpuErrchk(cudaMemcpy(d_i_neuron, i_neuron, n_neuron*sizeof(int),
+  // Memcopy will be synchronized with BaseNeuronGetFloatPtArray kernel
+  gpuErrchk(cudaMemcpyAsync(d_i_neuron, i_neuron, n_neuron*sizeof(int),
 		       cudaMemcpyHostToDevice));
 
   float *d_var_arr;
@@ -1482,7 +1492,7 @@ int BaseNeuron::BufferRecSpikeTimes()
   prefix_scan(n_rec_spike_times_cumul_, n_rec_spike_times_,
 	      n_node_+1, true);
   int *h_n_rec_spike_times_cumul = new int[n_node_+1];
-  gpuErrchk(cudaMemcpyAsync(h_n_rec_spike_times_cumul,
+  gpuErrchk(cudaMemcpy(h_n_rec_spike_times_cumul,
 			    n_rec_spike_times_cumul_,
 			    (n_node_+1)*sizeof(int), cudaMemcpyDeviceToHost));
   // the last element of the cumulative sum is the total number of spikes

--- a/src/node_group.cu
+++ b/src/node_group.cu
@@ -61,10 +61,11 @@ int NESTGPU::NodeGroupArrayInit()
     
     ngs_vect.push_back(ngs);
   }
-  gpuErrchk(cudaMemcpyToSymbol(NodeGroupArray, ngs_vect.data(),
+  gpuErrchk(cudaMemcpyToSymbolAsync(NodeGroupArray, ngs_vect.data(),
 			       ngs_vect.size()*sizeof(NodeGroupStruct)));
 
-  gpuErrchk(cudaMemcpy(d_node_group_map_, node_group_map_.data(),
+  // Memcopy will be synchronized with NodeGroupMapInit kernel
+  gpuErrchk(cudaMemcpyAsync(d_node_group_map_, node_group_map_.data(),
 		       node_group_map_.size()*sizeof(signed char),
 		       cudaMemcpyHostToDevice));
   NodeGroupMapInit<<<1, 1>>>(d_node_group_map_);

--- a/src/spike_mpi.cu
+++ b/src/spike_mpi.cu
@@ -422,7 +422,7 @@ int ConnectMpi::CopySpikeFromRemote(int n_hosts, int max_spike_per_host,
     time_mark = getRealTime();
     // Memcopy will be synchronized with AddOffset kernel
     // copy to GPU memory packed spikes from remote MPI proc
-    gpuErrchk(cudaMemcpyAsyc(d_ExternalSourceSpikeNodeId,
+    gpuErrchk(cudaMemcpyAsync(d_ExternalSourceSpikeNodeId,
 			 h_ExternalSourceSpikeNodeId,
 			 n_spike_tot*sizeof(int), cudaMemcpyHostToDevice));
     RecvSpikeFromRemote_CUDAcp_time_ += (getRealTime() - time_mark);

--- a/src/spike_mpi.cu
+++ b/src/spike_mpi.cu
@@ -317,7 +317,7 @@ int ConnectMpi::SendSpikeToRemote(int n_hosts, int max_spike_per_host)
   int n_spike_tot = JoinSpikes(n_hosts, max_spike_per_host);
 
   time_mark = getRealTime();
-    // copy spikes from GPU to CPU memory
+  // copy spikes from GPU to CPU memory
   gpuErrchk(cudaMemcpy(h_ExternalTargetSpikeNodeId,
 		       d_ExternalTargetSpikeNodeIdJoin,
 		       n_spike_tot*sizeof(int),
@@ -420,8 +420,9 @@ int ConnectMpi::CopySpikeFromRemote(int n_hosts, int max_spike_per_host,
 
   if (n_spike_tot>0) {
     time_mark = getRealTime();
+    // Memcopy will be synchronized with AddOffset kernel
     // copy to GPU memory packed spikes from remote MPI proc
-    gpuErrchk(cudaMemcpy(d_ExternalSourceSpikeNodeId,
+    gpuErrchk(cudaMemcpyAsyc(d_ExternalSourceSpikeNodeId,
 			 h_ExternalSourceSpikeNodeId,
 			 n_spike_tot*sizeof(int), cudaMemcpyHostToDevice));
     RecvSpikeFromRemote_CUDAcp_time_ += (getRealTime() - time_mark);

--- a/src/syn_model.cu
+++ b/src/syn_model.cu
@@ -219,9 +219,10 @@ int NESTGPU::SynGroupCalibrate()
   gpuErrchk(cudaMalloc(&d_SynGroupTypeMap, n_group*sizeof(int)));
   gpuErrchk(cudaMalloc(&d_SynGroupParamMap, n_group*sizeof(float*)));
 
-  gpuErrchk(cudaMemcpy(d_SynGroupTypeMap, h_SynGroupTypeMap,
+  // Memcopies will be synchronised with SynGroupInit kernel
+  gpuErrchk(cudaMemcpyAsync(d_SynGroupTypeMap, h_SynGroupTypeMap,
 		       n_group*sizeof(int), cudaMemcpyHostToDevice));
-  gpuErrchk(cudaMemcpy(d_SynGroupParamMap, h_SynGroupParamMap,
+  gpuErrchk(cudaMemcpyAsync(d_SynGroupParamMap, h_SynGroupParamMap,
 		       n_group*sizeof(float*), cudaMemcpyHostToDevice));
 
   SynGroupInit<<<1,1>>>(d_SynGroupTypeMap, d_SynGroupParamMap);


### PR DESCRIPTION
Fixes #4 .
Optimizations were done following [Asynchronous and Overlapping Transfers with Computation](https://docs.nvidia.com/cuda/cuda-c-best-practices-guide/index.html#asynchronous-transfers-and-overlapping-transfers-with-computation) from CUDA best practices guide.
Also note in BaseNeuron::BufferRecSpikeTimes from base_neuron.cu at line 1495 (previously 1485), memcpy was changed to synchronous because destination of copy is called directly after call with no previous synchronization mechanism.
Overall comparing with previous results of the multi-area model in the metastable state, we gained ~2s of simulation time.