### PR TITLE
Optimization of synchronization blocks

### DIFF
--- a/src/get_spike.cu
+++ b/src/get_spike.cu
@@ -169,7 +169,7 @@ int NESTGPU::ClearGetSpikeArrays()
   for (unsigned int i=0; i<node_vect_.size(); i++) {
     BaseNeuron *bn = node_vect_[i];
     if (bn->get_spike_array_ != NULL) {
-      gpuErrchk(cudaMemset(bn->get_spike_array_, 0, bn->n_node_*bn->n_port_
+      gpuErrchk(cudaMemsetAsync(bn->get_spike_array_, 0, bn->n_node_*bn->n_port_
 			   *sizeof(double)));
     }
   }

--- a/src/nestgpu.cu
+++ b/src/nestgpu.cu
@@ -533,6 +533,7 @@ int NESTGPU::SimulationStep()
     connect_mpi_->CopySpikeFromRemote(connect_mpi_->mpi_np_,
 				      max_spike_per_host_,
 				      i_remote_node_0_);
+    cudaDeviceSynchronize();
     MPI_Barrier(MPI_COMM_WORLD);
   }
 #endif

--- a/src/nestgpu.cu
+++ b/src/nestgpu.cu
@@ -545,7 +545,8 @@ int NESTGPU::SimulationStep()
   gpuErrchk(cudaMemcpyAsync(&n_spikes, d_SpikeNum, sizeof(int),
 		       cudaMemcpyDeviceToHost));
 
-  ClearGetSpikeArrays();    
+  ClearGetSpikeArrays(); 
+  gpuErrchk( cudaDeviceSynchronize() );   
   if (n_spikes > 0) {
     time_mark = getRealTime();
     CollectSpikeKernel<<<n_spikes, 1024>>>(n_spikes, d_SpikeTargetNum);
@@ -631,8 +632,8 @@ int NESTGPU::SimulationStep()
       // and if buffering is activated every n_step time steps...
       int n_step = node_vect_[i]->rec_spike_times_step_;
       if (n_step>0 && (time_idx%n_step == n_step-1)) {
-	// extract recorded spike times and put them in buffers
-	node_vect_[i]->BufferRecSpikeTimes();
+        // extract recorded spike times and put them in buffers
+        node_vect_[i]->BufferRecSpikeTimes();
       }
     }
   }

--- a/src/nestgpu.cu
+++ b/src/nestgpu.cu
@@ -599,7 +599,7 @@ int NESTGPU::SimulationStep()
     time_mark = getRealTime();
     ExternalSpikeReset<<<1, 1>>>();
     gpuErrchk( cudaPeekAtLastError() );
-    gpuErrchk( cudaDeviceSynchronize() );
+    //gpuErrchk( cudaDeviceSynchronize() );
     ExternalSpikeReset_time_ += (getRealTime() - time_mark);
   }
 #endif

--- a/src/nestgpu.cu
+++ b/src/nestgpu.cu
@@ -612,7 +612,7 @@ int NESTGPU::SimulationStep()
     RevSpikeBufferUpdate<<<(net_connection_->connection_.size()+1023)/1024,
       1024>>>(net_connection_->connection_.size());
     gpuErrchk( cudaPeekAtLastError() );
-    gpuErrchk( cudaDeviceSynchronize() );
+    //gpuErrchk( cudaDeviceSynchronize() );
     unsigned int n_rev_spikes;
     gpuErrchk(cudaMemcpy(&n_rev_spikes, d_RevSpikeNum, sizeof(unsigned int),
 			 cudaMemcpyDeviceToHost));

--- a/src/nestgpu.cu
+++ b/src/nestgpu.cu
@@ -608,7 +608,7 @@ int NESTGPU::SimulationStep()
     //time_mark = getRealTime();
     RevSpikeReset<<<1, 1>>>();
     gpuErrchk( cudaPeekAtLastError() );
-    gpuErrchk( cudaDeviceSynchronize() );
+    //gpuErrchk( cudaDeviceSynchronize() );
     RevSpikeBufferUpdate<<<(net_connection_->connection_.size()+1023)/1024,
       1024>>>(net_connection_->connection_.size());
     gpuErrchk( cudaPeekAtLastError() );

--- a/src/nestgpu.cu
+++ b/src/nestgpu.cu
@@ -516,7 +516,7 @@ int NESTGPU::SimulationStep()
       time_mark = getRealTime();
       SendExternalSpike<<<(n_ext_spike+1023)/1024, 1024>>>();
       gpuErrchk( cudaPeekAtLastError() );
-      gpuErrchk( cudaDeviceSynchronize() );
+      //gpuErrchk( cudaDeviceSynchronize() );
       SendExternalSpike_time_ += (getRealTime() - time_mark);
     }
     //for (int ih=0; ih<connect_mpi_->mpi_np_; ih++) {

--- a/src/nestgpu.cu
+++ b/src/nestgpu.cu
@@ -546,6 +546,7 @@ int NESTGPU::SimulationStep()
 		       cudaMemcpyDeviceToHost));
 
   ClearGetSpikeArrays();    
+  gpuErrchk( cudaDeviceSynchronize() );   
   if (n_spikes > 0) {
     time_mark = getRealTime();
     CollectSpikeKernel<<<n_spikes, 1024>>>(n_spikes, d_SpikeTargetNum);

--- a/src/nestgpu.cu
+++ b/src/nestgpu.cu
@@ -584,7 +584,7 @@ int NESTGPU::SimulationStep()
     }
   }
   gpuErrchk( cudaPeekAtLastError() );
-  gpuErrchk( cudaDeviceSynchronize() );
+  //gpuErrchk( cudaDeviceSynchronize() );
 
   GetSpike_time_ += (getRealTime() - time_mark);
 

--- a/src/nestgpu.cu
+++ b/src/nestgpu.cu
@@ -499,7 +499,7 @@ int NESTGPU::SimulationStep()
     node_vect_[i]->Update(it_, neural_time_);
   }
   gpuErrchk( cudaPeekAtLastError() );
-  gpuErrchk( cudaDeviceSynchronize() );
+  //gpuErrchk( cudaDeviceSynchronize() );
   
   neuron_Update_time_ += (getRealTime() - time_mark);
   multimeter_->WriteRecords(neural_time_);

--- a/src/nestgpu.cu
+++ b/src/nestgpu.cu
@@ -591,7 +591,7 @@ int NESTGPU::SimulationStep()
   time_mark = getRealTime();
   SpikeReset<<<1, 1>>>();
   gpuErrchk( cudaPeekAtLastError() );
-  gpuErrchk( cudaDeviceSynchronize() );
+  //gpuErrchk( cudaDeviceSynchronize() );
   SpikeReset_time_ += (getRealTime() - time_mark);
 
 #ifdef HAVE_MPI

--- a/src/nestgpu.cu
+++ b/src/nestgpu.cu
@@ -540,7 +540,9 @@ int NESTGPU::SimulationStep()
     
   int n_spikes;
   time_mark = getRealTime();
-  gpuErrchk(cudaMemcpy(&n_spikes, d_SpikeNum, sizeof(int),
+  // Call will get delayed until ClearGetSpikesArrays()
+  // afterwards the value of n_spikes will be available
+  gpuErrchk(cudaMemcpyAsync(&n_spikes, d_SpikeNum, sizeof(int),
 		       cudaMemcpyDeviceToHost));
 
   ClearGetSpikeArrays();    

--- a/src/nestgpu.cu
+++ b/src/nestgpu.cu
@@ -619,7 +619,7 @@ int NESTGPU::SimulationStep()
     if (n_rev_spikes > 0) {
       SynapseUpdateKernel<<<n_rev_spikes, 1024>>>(n_rev_spikes, d_RevSpikeNConn);
       gpuErrchk(cudaPeekAtLastError());
-      gpuErrchk(cudaDeviceSynchronize());
+      //gpuErrchk(cudaDeviceSynchronize());
 
     }      
     //RevSpikeBufferUpdate_time_ += (getRealTime() - time_mark);

--- a/src/nestgpu.cu
+++ b/src/nestgpu.cu
@@ -473,7 +473,7 @@ int NESTGPU::SimulationStep()
   SpikeBufferUpdate<<<(net_connection_->connection_.size()+1023)/1024,
     1024>>>();
   gpuErrchk( cudaPeekAtLastError() );
-  gpuErrchk( cudaDeviceSynchronize() );
+  //gpuErrchk( cudaDeviceSynchronize() );
   SpikeBufferUpdate_time_ += (getRealTime() - time_mark);
   time_mark = getRealTime();
   if (n_poiss_node_>0) {

--- a/src/nestgpu.cu
+++ b/src/nestgpu.cu
@@ -533,7 +533,7 @@ int NESTGPU::SimulationStep()
     connect_mpi_->CopySpikeFromRemote(connect_mpi_->mpi_np_,
 				      max_spike_per_host_,
 				      i_remote_node_0_);
-    cudaDeviceSynchronize();
+    //gpuErrchk( cudaDeviceSynchronize() );
     MPI_Barrier(MPI_COMM_WORLD);
   }
 #endif
@@ -546,7 +546,6 @@ int NESTGPU::SimulationStep()
 		       cudaMemcpyDeviceToHost));
 
   ClearGetSpikeArrays();    
-  gpuErrchk( cudaDeviceSynchronize() );   
   if (n_spikes > 0) {
     time_mark = getRealTime();
     CollectSpikeKernel<<<n_spikes, 1024>>>(n_spikes, d_SpikeTargetNum);

--- a/src/nestgpu.cu
+++ b/src/nestgpu.cu
@@ -475,7 +475,6 @@ int NESTGPU::SimulationStep()
   SpikeBufferUpdate<<<(net_connection_->connection_.size()+1023)/1024,
     1024>>>();
   gpuErrchk( cudaPeekAtLastError() );
-  //gpuErrchk( cudaDeviceSynchronize() );
   SpikeBufferUpdate_time_ += (getRealTime() - time_mark);
   time_mark = getRealTime();
   if (n_poiss_node_>0) {
@@ -501,7 +500,6 @@ int NESTGPU::SimulationStep()
     node_vect_[i]->Update(it_, neural_time_);
   }
   gpuErrchk( cudaPeekAtLastError() );
-  //gpuErrchk( cudaDeviceSynchronize() );
   
   neuron_Update_time_ += (getRealTime() - time_mark);
   multimeter_->WriteRecords(neural_time_);
@@ -518,7 +516,6 @@ int NESTGPU::SimulationStep()
       time_mark = getRealTime();
       SendExternalSpike<<<(n_ext_spike+1023)/1024, 1024>>>();
       gpuErrchk( cudaPeekAtLastError() );
-      //gpuErrchk( cudaDeviceSynchronize() );
       SendExternalSpike_time_ += (getRealTime() - time_mark);
     }
     //for (int ih=0; ih<connect_mpi_->mpi_np_; ih++) {
@@ -535,7 +532,6 @@ int NESTGPU::SimulationStep()
     connect_mpi_->CopySpikeFromRemote(connect_mpi_->mpi_np_,
 				      max_spike_per_host_,
 				      i_remote_node_0_);
-    //gpuErrchk( cudaDeviceSynchronize() );
     MPI_Barrier(MPI_COMM_WORLD);
   }
 #endif
@@ -582,19 +578,15 @@ int NESTGPU::SimulationStep()
 	 node_vect_[i]->port_input_arr_,
 	 node_vect_[i]->port_input_arr_step_,
 	 node_vect_[i]->port_input_port_step_);
-      // gpuErrchk( cudaPeekAtLastError() );
-      // gpuErrchk( cudaDeviceSynchronize() );
     }
   }
   gpuErrchk( cudaPeekAtLastError() );
-  //gpuErrchk( cudaDeviceSynchronize() );
 
   GetSpike_time_ += (getRealTime() - time_mark);
 
   time_mark = getRealTime();
   SpikeReset<<<1, 1>>>();
   gpuErrchk( cudaPeekAtLastError() );
-  //gpuErrchk( cudaDeviceSynchronize() );
   SpikeReset_time_ += (getRealTime() - time_mark);
 
 #ifdef HAVE_MPI
@@ -602,7 +594,6 @@ int NESTGPU::SimulationStep()
     time_mark = getRealTime();
     ExternalSpikeReset<<<1, 1>>>();
     gpuErrchk( cudaPeekAtLastError() );
-    //gpuErrchk( cudaDeviceSynchronize() );
     ExternalSpikeReset_time_ += (getRealTime() - time_mark);
   }
 #endif
@@ -611,19 +602,15 @@ int NESTGPU::SimulationStep()
     //time_mark = getRealTime();
     RevSpikeReset<<<1, 1>>>();
     gpuErrchk( cudaPeekAtLastError() );
-    //gpuErrchk( cudaDeviceSynchronize() );
     RevSpikeBufferUpdate<<<(net_connection_->connection_.size()+1023)/1024,
       1024>>>(net_connection_->connection_.size());
     gpuErrchk( cudaPeekAtLastError() );
-    //gpuErrchk( cudaDeviceSynchronize() );
     unsigned int n_rev_spikes;
     gpuErrchk(cudaMemcpy(&n_rev_spikes, d_RevSpikeNum, sizeof(unsigned int),
 			 cudaMemcpyDeviceToHost));
     if (n_rev_spikes > 0) {
       SynapseUpdateKernel<<<n_rev_spikes, 1024>>>(n_rev_spikes, d_RevSpikeNConn);
       gpuErrchk(cudaPeekAtLastError());
-      //gpuErrchk(cudaDeviceSynchronize());
-
     }      
     //RevSpikeBufferUpdate_time_ += (getRealTime() - time_mark);
   }

--- a/src/node_group.cu
+++ b/src/node_group.cu
@@ -69,6 +69,7 @@ int NESTGPU::NodeGroupArrayInit()
 		       node_group_map_.size()*sizeof(signed char),
 		       cudaMemcpyHostToDevice));
   NodeGroupMapInit<<<1, 1>>>(d_node_group_map_);
+  gpuErrchk( cudaPeekAtLastError() );
 
   return 0;
 }

--- a/src/poisson.cu
+++ b/src/poisson.cu
@@ -89,10 +89,10 @@ int PoissonGenerator::Generate(int max_n_steps)
   // Generate N floats on device
   CURAND_CALL(curandGeneratePoisson(*random_generator_, dev_poisson_data_,
 				    n_node_*more_steps_, lambda_));
-  cudaDeviceSynchronize();
+  //cudaDeviceSynchronize();
   FixPoissonGenerator<<<(n_node_+1023)/1024, 1024>>>
     (dev_poisson_data_,n_node_*more_steps_, lambda_);
-  cudaDeviceSynchronize();
+  //cudaDeviceSynchronize();
 
   return 0;
 }

--- a/src/poisson.cu
+++ b/src/poisson.cu
@@ -91,10 +91,8 @@ int PoissonGenerator::Generate(int max_n_steps)
   // Generate N floats on device
   CURAND_CALL(curandGeneratePoisson(*random_generator_, dev_poisson_data_,
 				    n_node_*more_steps_, lambda_));
-  //cudaDeviceSynchronize();
   FixPoissonGenerator<<<(n_node_+1023)/1024, 1024>>>
     (dev_poisson_data_,n_node_*more_steps_, lambda_);
-  //cudaDeviceSynchronize();
 
   return 0;
 }
@@ -146,11 +144,9 @@ int PoissonGenerator::Update(int max_n_steps)
   
   PoissonUpdate<<<1, 1>>>(&dev_poisson_data_[i_step_*n_node_]);
   gpuErrchk( cudaPeekAtLastError() );
-  //gpuErrchk( cudaDeviceSynchronize() );
 
   PoissonSendSpikes<<<(n_node_+1023)/1024, 1024>>>(i_node_0_, n_node_);
   gpuErrchk( cudaPeekAtLastError() );
-  //gpuErrchk( cudaDeviceSynchronize() );
 
   i_step_++;
   if (i_step_ == n_steps_) i_step_ = 0;

--- a/src/poisson.cu
+++ b/src/poisson.cu
@@ -144,11 +144,11 @@ int PoissonGenerator::Update(int max_n_steps)
   
   PoissonUpdate<<<1, 1>>>(&dev_poisson_data_[i_step_*n_node_]);
   gpuErrchk( cudaPeekAtLastError() );
-  gpuErrchk( cudaDeviceSynchronize() );
+  //gpuErrchk( cudaDeviceSynchronize() );
 
   PoissonSendSpikes<<<(n_node_+1023)/1024, 1024>>>(i_node_0_, n_node_);
   gpuErrchk( cudaPeekAtLastError() );
-  gpuErrchk( cudaDeviceSynchronize() );
+  //gpuErrchk( cudaDeviceSynchronize() );
 
   i_step_++;
   if (i_step_ == n_steps_) i_step_ = 0;

--- a/src/rev_spike.cu
+++ b/src/rev_spike.cu
@@ -187,7 +187,7 @@ int RevSpikeInit(NetConnection *net_connection)
   DeviceRevSpikeInit<<<1,1>>>(d_RevSpikeNum, d_RevSpikeTarget,
 			      d_RevSpikeNConn);
   gpuErrchk( cudaPeekAtLastError() );
-  gpuErrchk( cudaDeviceSynchronize() );
+  //gpuErrchk( cudaDeviceSynchronize() );
 
   return 0;
 }

--- a/src/rev_spike.cu
+++ b/src/rev_spike.cu
@@ -175,7 +175,7 @@ int RevSpikeInit(NetConnection *net_connection)
     <<<(net_connection->StoredNConnections()+1023)/1024, 1024>>>
     (net_connection->StoredNConnections(), 0x8000);
   gpuErrchk( cudaPeekAtLastError() );
-  gpuErrchk( cudaDeviceSynchronize() );
+  //gpuErrchk( cudaDeviceSynchronize() );
 
   gpuErrchk(cudaMalloc(&d_RevSpikeNum, sizeof(unsigned int)));
   

--- a/src/rev_spike.cu
+++ b/src/rev_spike.cu
@@ -162,7 +162,7 @@ int ResetConnectionSpikeTimeDown(NetConnection *net_connection)
     <<<(net_connection->StoredNConnections()+1023)/1024, 1024>>>
     (net_connection->StoredNConnections());
   gpuErrchk( cudaPeekAtLastError() );
-  gpuErrchk( cudaDeviceSynchronize() );
+  //gpuErrchk( cudaDeviceSynchronize() );
 
   return 0;
 }

--- a/src/rev_spike.cu
+++ b/src/rev_spike.cu
@@ -153,7 +153,6 @@ int ResetConnectionSpikeTimeUp(NetConnection *net_connection)
     <<<(net_connection->StoredNConnections()+1023)/1024, 1024>>>
     (net_connection->StoredNConnections());
   gpuErrchk( cudaPeekAtLastError() );
-  //gpuErrchk( cudaDeviceSynchronize() );
 
   return 0;
 }
@@ -164,7 +163,6 @@ int ResetConnectionSpikeTimeDown(NetConnection *net_connection)
     <<<(net_connection->StoredNConnections()+1023)/1024, 1024>>>
     (net_connection->StoredNConnections());
   gpuErrchk( cudaPeekAtLastError() );
-  //gpuErrchk( cudaDeviceSynchronize() );
 
   return 0;
 }
@@ -177,7 +175,6 @@ int RevSpikeInit(NetConnection *net_connection)
     <<<(net_connection->StoredNConnections()+1023)/1024, 1024>>>
     (net_connection->StoredNConnections(), 0x8000);
   gpuErrchk( cudaPeekAtLastError() );
-  //gpuErrchk( cudaDeviceSynchronize() );
 
   gpuErrchk(cudaMalloc(&d_RevSpikeNum, sizeof(unsigned int)));
   
@@ -189,7 +186,6 @@ int RevSpikeInit(NetConnection *net_connection)
   DeviceRevSpikeInit<<<1,1>>>(d_RevSpikeNum, d_RevSpikeTarget,
 			      d_RevSpikeNConn);
   gpuErrchk( cudaPeekAtLastError() );
-  //gpuErrchk( cudaDeviceSynchronize() );
 
   return 0;
 }

--- a/src/rev_spike.cu
+++ b/src/rev_spike.cu
@@ -151,7 +151,7 @@ int ResetConnectionSpikeTimeUp(NetConnection *net_connection)
     <<<(net_connection->StoredNConnections()+1023)/1024, 1024>>>
     (net_connection->StoredNConnections());
   gpuErrchk( cudaPeekAtLastError() );
-  gpuErrchk( cudaDeviceSynchronize() );
+  //gpuErrchk( cudaDeviceSynchronize() );
 
   return 0;
 }

--- a/src/send_spike.cu
+++ b/src/send_spike.cu
@@ -85,7 +85,6 @@ void SpikeInit(int max_spike_num)
   DeviceSpikeInit<<<1,1>>>(d_SpikeNum, d_SpikeSourceIdx, d_SpikeConnIdx,
 			   d_SpikeHeight, d_SpikeTargetNum, max_spike_num);
   gpuErrchk( cudaPeekAtLastError() );
-  //gpuErrchk( cudaDeviceSynchronize() );
 }
 
 __global__ void SpikeReset()

--- a/src/send_spike.cu
+++ b/src/send_spike.cu
@@ -83,7 +83,7 @@ void SpikeInit(int max_spike_num)
   DeviceSpikeInit<<<1,1>>>(d_SpikeNum, d_SpikeSourceIdx, d_SpikeConnIdx,
 			   d_SpikeHeight, d_SpikeTargetNum, max_spike_num);
   gpuErrchk( cudaPeekAtLastError() );
-  gpuErrchk( cudaDeviceSynchronize() );
+  //gpuErrchk( cudaDeviceSynchronize() );
 }
 
 __global__ void SpikeReset()

--- a/src/spike_buffer.cu
+++ b/src/spike_buffer.cu
@@ -473,8 +473,12 @@ int SpikeBufferInit(NetConnection *net_connection, int max_spike_buffer_size)
 	     cudaMemcpyHostToDevice);
     cudaMemcpyAsync(d_TargetRevConnectionSize, h_target_rev_conn_size,
 	       n_spike_buffers*sizeof(int), cudaMemcpyHostToDevice);
-    cudaMemcpyAsync(d_TargetRevConnection, h_target_rev_conn,
+    cudaMemcpy(d_TargetRevConnection, h_target_rev_conn,
 	       n_spike_buffers*sizeof(unsigned int*), cudaMemcpyHostToDevice);
+
+    delete[] h_rev_conn;
+    delete[] h_target_rev_conn_size;
+    delete[] h_target_rev_conn;
   }
   
   cudaMemcpyAsync(d_ConnectionGroupSize, h_ConnectionGroupSize,
@@ -534,12 +538,6 @@ int SpikeBufferInit(NetConnection *net_connection, int max_spike_buffer_size)
 
   delete[] h_conn_target;
   delete[] h_conn_syn_group;
-
-  if (n_rev_conn>0) {
-    delete[] h_rev_conn;
-    delete[] h_target_rev_conn_size;
-    delete[] h_target_rev_conn;
-  }
 
   delete[] h_ConnectionGroupSize;
   delete[] h_ConnectionGroupDelay;

--- a/src/spike_buffer.cu
+++ b/src/spike_buffer.cu
@@ -526,7 +526,6 @@ int SpikeBufferInit(NetConnection *net_connection, int max_spike_buffer_size)
 			   d_TargetRevConnection, d_LastRevSpikeTimeIdx
 				 );
   gpuErrchk( cudaPeekAtLastError() );
-  //gpuErrchk( cudaDeviceSynchronize() );
   
   InitLastSpikeTimeIdx
     <<<(n_spike_buffers+1023)/1024, 1024>>>

--- a/src/spike_buffer.cu
+++ b/src/spike_buffer.cu
@@ -371,8 +371,8 @@ int SpikeBufferInit(NetConnection *net_connection, int max_spike_buffer_size)
 		       n_spike_buffers*max_spike_buffer_size*sizeof(int)));
   gpuErrchk(cudaMalloc(&d_SpikeBufferHeight,
 		       n_spike_buffers*max_spike_buffer_size*sizeof(float)));
-  gpuErrchk(cudaMemset(d_SpikeBufferSize, 0, n_spike_buffers*sizeof(int)));
-  gpuErrchk(cudaMemset(d_SpikeBufferIdx0, 0, n_spike_buffers*sizeof(int)));
+  gpuErrchk(cudaMemsetAsync(d_SpikeBufferSize, 0, n_spike_buffers*sizeof(int)));
+  gpuErrchk(cudaMemsetAsync(d_SpikeBufferIdx0, 0, n_spike_buffers*sizeof(int)));
 
   gpuErrchk(cudaMalloc(&d_ConnectionGroupTargetNode,
 		     n_spike_buffers*max_delay_num*sizeof(unsigned int*)));
@@ -427,14 +427,13 @@ int SpikeBufferInit(NetConnection *net_connection, int max_spike_buffer_size)
    }
   }
   
-  cudaMemcpy(d_conn_target, h_conn_target, n_conn*sizeof(unsigned int),
+  cudaMemcpyAsync(d_conn_target, h_conn_target, n_conn*sizeof(unsigned int),
 	     cudaMemcpyHostToDevice);
-  cudaMemcpy(d_ConnectionSynGroup, h_conn_syn_group,
+  cudaMemcpyAsync(d_ConnectionSynGroup, h_conn_syn_group,
 	     n_conn*sizeof(unsigned char), cudaMemcpyHostToDevice);
-  cudaMemcpy(d_ConnectionWeight, h_conn_weight, n_conn*sizeof(float),
+  cudaMemcpyAsync(d_ConnectionWeight, h_conn_weight, n_conn*sizeof(float),
 	     cudaMemcpyHostToDevice);
 
-  delete[] h_conn_weight;
 
   unsigned int n_rev_conn = 0;
   std::vector<std::vector<unsigned int> > rev_connections(n_spike_buffers);
@@ -446,9 +445,6 @@ int SpikeBufferInit(NetConnection *net_connection, int max_spike_buffer_size)
       rev_connections[target].push_back(i_conn);
     }
   }
-  
-  delete[] h_conn_target;
-  delete[] h_conn_syn_group;
   
   net_connection->SetNRevConnections(n_rev_conn);
 
@@ -473,38 +469,34 @@ int SpikeBufferInit(NetConnection *net_connection, int max_spike_buffer_size)
 	i_rev_conn++;
       }
     }
-    cudaMemcpy(d_RevConnections, h_rev_conn, n_rev_conn*sizeof(unsigned int),
+    cudaMemcpyAsync(d_RevConnections, h_rev_conn, n_rev_conn*sizeof(unsigned int),
 	     cudaMemcpyHostToDevice);
-    cudaMemcpy(d_TargetRevConnectionSize, h_target_rev_conn_size,
+    cudaMemcpyAsync(d_TargetRevConnectionSize, h_target_rev_conn_size,
 	       n_spike_buffers*sizeof(int), cudaMemcpyHostToDevice);
-    cudaMemcpy(d_TargetRevConnection, h_target_rev_conn,
+    cudaMemcpyAsync(d_TargetRevConnection, h_target_rev_conn,
 	       n_spike_buffers*sizeof(unsigned int*), cudaMemcpyHostToDevice);
-    
-    delete[] h_rev_conn;
-    delete[] h_target_rev_conn_size;
-    delete[] h_target_rev_conn;
   }
   
-  cudaMemcpy(d_ConnectionGroupSize, h_ConnectionGroupSize,
+  cudaMemcpyAsync(d_ConnectionGroupSize, h_ConnectionGroupSize,
 	     n_spike_buffers*sizeof(int), cudaMemcpyHostToDevice);
-  cudaMemcpy(d_ConnectionGroupDelay, h_ConnectionGroupDelay,
+  cudaMemcpyAsync(d_ConnectionGroupDelay, h_ConnectionGroupDelay,
 	     n_spike_buffers*max_delay_num*sizeof(int), cudaMemcpyHostToDevice);
-  cudaMemcpy(d_ConnectionGroupTargetSize, h_ConnectionGroupTargetSize,
+  cudaMemcpyAsync(d_ConnectionGroupTargetSize, h_ConnectionGroupTargetSize,
 	     n_spike_buffers*max_delay_num*sizeof(int), cudaMemcpyHostToDevice);
 
-  cudaMemcpy(d_ConnectionGroupTargetNode, h_ConnectionGroupTargetNode,
+  cudaMemcpyAsync(d_ConnectionGroupTargetNode, h_ConnectionGroupTargetNode,
 	     n_spike_buffers*max_delay_num*sizeof(unsigned int*),
 	     cudaMemcpyHostToDevice);
   
-  cudaMemcpy(d_ConnectionGroupTargetSynGroup, h_ConnectionGroupTargetSynGroup,
+  cudaMemcpyAsync(d_ConnectionGroupTargetSynGroup, h_ConnectionGroupTargetSynGroup,
 	     n_spike_buffers*max_delay_num*sizeof(unsigned char*),
 	     cudaMemcpyHostToDevice);
   
-  cudaMemcpy(d_ConnectionGroupTargetWeight, h_ConnectionGroupTargetWeight,
+  cudaMemcpyAsync(d_ConnectionGroupTargetWeight, h_ConnectionGroupTargetWeight,
 	     n_spike_buffers*max_delay_num*sizeof(float*),
 	     cudaMemcpyHostToDevice);
   if(ConnectionSpikeTimeFlag) {
-    cudaMemcpy(d_ConnectionGroupTargetSpikeTime,
+    cudaMemcpyAsync(d_ConnectionGroupTargetSpikeTime,
 	       h_ConnectionGroupTargetSpikeTime,
 	       n_spike_buffers*max_delay_num*sizeof(unsigned short*),
 	       cudaMemcpyHostToDevice);
@@ -528,15 +520,26 @@ int SpikeBufferInit(NetConnection *net_connection, int max_spike_buffer_size)
 			   d_TargetRevConnection, d_LastRevSpikeTimeIdx
 				 );
   gpuErrchk( cudaPeekAtLastError() );
-  gpuErrchk( cudaDeviceSynchronize() );
+  //gpuErrchk( cudaDeviceSynchronize() );
   
   InitLastSpikeTimeIdx
     <<<(n_spike_buffers+1023)/1024, 1024>>>
     (n_spike_buffers, LAST_SPIKE_TIME_GUARD);
   gpuErrchk( cudaPeekAtLastError() );
-  gpuErrchk( cudaDeviceSynchronize() );
-  gpuErrchk(cudaMemset(d_LastSpikeHeight, 0,
+  gpuErrchk(cudaMemsetAsync(d_LastSpikeHeight, 0,
 		       n_spike_buffers*sizeof(unsigned short)));
+  gpuErrchk( cudaDeviceSynchronize() );
+
+  delete[] h_conn_weight;
+
+  delete[] h_conn_target;
+  delete[] h_conn_syn_group;
+
+  if (n_rev_conn>0) {
+    delete[] h_rev_conn;
+    delete[] h_target_rev_conn_size;
+    delete[] h_target_rev_conn;
+  }
 
   delete[] h_ConnectionGroupSize;
   delete[] h_ConnectionGroupDelay;

--- a/src/spike_mpi.cu
+++ b/src/spike_mpi.cu
@@ -251,7 +251,7 @@ int ConnectMpi::ExternalSpikeInit(int n_node, int n_hosts, int max_spike_per_hos
          target_host_arr[ith] = conn->at(ith).target_host_id;
          node_id_arr[ith] = conn->at(ith).remote_node_id;
        }
-       cudaMemcpy(h_ExternalNodeTargetHostId[i_source], target_host_arr,
+       cudaMemcpyAsync(h_ExternalNodeTargetHostId[i_source], target_host_arr,
    	       Nth*sizeof(int), cudaMemcpyHostToDevice);
        cudaMemcpy(h_ExternalNodeId[i_source], node_id_arr,
    	       Nth*sizeof(int), cudaMemcpyHostToDevice);
@@ -259,11 +259,11 @@ int ConnectMpi::ExternalSpikeInit(int n_node, int n_hosts, int max_spike_per_hos
        delete[] node_id_arr;
      }
   }
-  cudaMemcpy(d_NExternalNodeTargetHost, h_NExternalNodeTargetHost,
+  cudaMemcpyAsync(d_NExternalNodeTargetHost, h_NExternalNodeTargetHost,
 	     n_node*sizeof(int), cudaMemcpyHostToDevice);
-  cudaMemcpy(d_ExternalNodeTargetHostId, h_ExternalNodeTargetHostId,
+  cudaMemcpyAsync(d_ExternalNodeTargetHostId, h_ExternalNodeTargetHostId,
 	     n_node*sizeof(int*), cudaMemcpyHostToDevice);
-  cudaMemcpy(d_ExternalNodeId, h_ExternalNodeId,
+  cudaMemcpyAsync(d_ExternalNodeId, h_ExternalNodeId,
 	     n_node*sizeof(int*), cudaMemcpyHostToDevice);
 
   DeviceExternalSpikeInit<<<1,1>>>(n_hosts, max_spike_per_host,
@@ -277,6 +277,9 @@ int ConnectMpi::ExternalSpikeInit(int n_node, int n_hosts, int max_spike_per_hos
 				   d_ExternalNodeTargetHostId,
 				   d_ExternalNodeId
 				   );
+  gpuErrchk( cudaPeekAtLastError() );
+  gpuErrchk( cudaDeviceSynchronize() );
+
   delete[] h_NExternalNodeTargetHost;
   delete[] h_ExternalNodeTargetHostId;
   delete[] h_ExternalNodeId;

--- a/src/spike_mpi.h
+++ b/src/spike_mpi.h
@@ -42,9 +42,6 @@ Args:
 __global__ void PushSpikeFromRemote(int n_spikes, int *spike_buffer_id,
                                     float *spike_height = NULL, int offset = 0);
 
-//__global__ void PushSpikeFromRemote(int n_spikes, int *spike_buffer_id);
-
-
 #ifdef HAVE_MPI
 
 extern __constant__ bool NESTGPUMpiFlag;

--- a/src/spike_mpi.h
+++ b/src/spike_mpi.h
@@ -25,10 +25,22 @@
 #ifndef SPIKEMPI_H
 #define SPIKEMPI_H
 
+/*
+Combined version of PushedSpikeFromRemote and AddOffset kernels
+using default values for arguments
+Args:
+	- int n_spikes: number of spikes to push
+	- int* spike_buffer_id: pointer to array of spike buffer ids
+	- float* spike_height: pointer to array of spike heights to send
+		Defaults to NULL, if no spike height given then a height of 1.0 is pushed
+		Must be of length == n_spikes
+	- int offset: Offset to be used for spike_buffer indexes
+		Defaults to 0
+*/
 __global__ void PushSpikeFromRemote(int n_spikes, int *spike_buffer_id,
-                                    float *spike_height);
+                                    float *spike_height = NULL, int offset = 0);
 
-__global__ void PushSpikeFromRemote(int n_spikes, int *spike_buffer_id);
+//__global__ void PushSpikeFromRemote(int n_spikes, int *spike_buffer_id);
 
 
 #ifdef HAVE_MPI


### PR DESCRIPTION
Following GPU operation ordering mechanisms ( https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#ordering-and-concurrency ), synchronization instructions were evaluated and removed when possible to streamline simulation loop.