### PR TITLE
Add placeholder comments for NESTML generated files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -140,6 +140,9 @@ set ( nestgpu_sources
 	test_syn_model.cu
 	user_m1.cu
 	user_m2.cu
+    # <<BEGIN_NESTML_GENERATED>>
+
+    # <<END_NESTML_GENERATED>>
 	connect_rules.cpp
 	nestgpu_C.cpp
     )

--- a/src/neuron_models.cu
+++ b/src/neuron_models.cu
@@ -56,6 +56,9 @@
 #include "izhikevich_psc_exp.h"
 #include "user_m1.h"
 #include "user_m2.h"
+// <<BEGIN_NESTML_GENERATED>>
+
+// <<END_NESTML_GENERATED>>
 
 NodeSeq NESTGPU::Create(std::string model_name, int n_node /*=1*/,
 			  int n_port /*=1*/)
@@ -177,6 +180,9 @@ NodeSeq NESTGPU::Create(std::string model_name, int n_node /*=1*/,
     izhikevich_psc_exp *izhikevich_psc_exp_group = new izhikevich_psc_exp;
     node_vect_.push_back(izhikevich_psc_exp_group);
   }
+  // <<BEGIN_NESTML_GENERATED>>
+
+  // <<END_NESTML_GENERATED>>
   else {
     throw ngpu_exception(std::string("Unknown neuron model name: ")
 			 + model_name);

--- a/src/neuron_models.h
+++ b/src/neuron_models.h
@@ -53,6 +53,9 @@ enum NeuronModels {
   i_izhikevich_psc_exp_model,
   i_user_m1_model,
   i_user_m2_model,
+  // <<BEGIN_NESTML_GENERATED>>
+
+  // <<END_NESTML_GENERATED>>
   N_NEURON_MODELS
 };
 
@@ -82,6 +85,9 @@ const std::string neuron_model_name[N_NEURON_MODELS] = {
   "izhikevich_psc_exp",
   "user_m1",
   "user_m2"
+  // <<BEGIN_NESTML_GENERATED>>
+
+  // <<END_NESTML_GENERATED>>
 };
 
 #endif


### PR DESCRIPTION
The placeholder comments are used as a key to place the `.h` and `.cu` neuron model files generated from NESTML.