### PR TITLE
Updated CMake for HPC benchmark implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ libtool
 /.settings/
 doxygen
 python/test/log.txt
+.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,9 +45,10 @@ endif()
 ################################################################################
 
 # select parallelization scheme
-set( with-gpu-arch "70" CACHE STRING "Specify the GPU compute architecture [default=70]." )
+set( with-gpu-arch "80" CACHE STRING "Specify the GPU compute architecture [default=80]." )
 set( with-mpi ON CACHE STRING "Build with MPI parallelization [default=ON]." )
-set( with-openmp ON CACHE BOOL "Build with OpenMP multi-threading [default=ON]. Optionally set OMP compiler flags." )
+# Disabled by default due to the mishandling of RNGs in multi-threaded network construction.
+set( with-openmp OFF CACHE BOOL "Build with OpenMP multi-threading [default=OFF]. Optionally set OMP compiler flags." )
 
 # external libraries
 # libltdl not yet needed but will be useful for NESTML

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,6 +50,7 @@ set ( nestgpu_sources
 	ext_neuron.h
 	getRealTime.h
 	get_spike.h
+	iaf_psc_alpha.h
 	iaf_psc_exp_g.h
 	iaf_psc_exp.h
 	iaf_psc_exp_hc.h
@@ -74,6 +75,7 @@ set ( nestgpu_sources
 	poisson.h
 	prefix_scan.h
 	propagate_error.h
+	propagator_stability.h
 	random.h
 	rev_spike.h
 	rk5_const.h
@@ -109,6 +111,7 @@ set ( nestgpu_sources
 	ext_neuron.cu
 	getRealTime.cu
 	get_spike.cu
+	iaf_psc_alpha.cu
 	iaf_psc_exp.cu
 	iaf_psc_exp_g.cu
 	iaf_psc_exp_hc.cu
@@ -126,6 +129,7 @@ set ( nestgpu_sources
 	poiss_gen.cu
 	poisson.cu
 	prefix_scan.cu
+	propagator_stability.cu
 	random.cu
 	rev_spike.cu
 	rk5.cu


### PR DESCRIPTION
Added new source files.
Changed default value for OpenMP to false due to multi-threading issue on network construction (no fix will be done due to the deprecation of the CPU construction method in favor of GPU construction).
Updated default GPU architecture value to 80 (widely supported by modern GPUs -> A100s, H100s, RTX3000s, RTX4000s).