### PR TITLE
Fixed templating issue after CUB fix

### DIFF
--- a/src/poiss_gen.cu
+++ b/src/poiss_gen.cu
@@ -60,11 +60,10 @@ namespace poiss_conn
 // max delay functor
 struct MaxDelay
 {
-    template <typename T, typename U>
     __device__ __forceinline__
-    auto operator()(const T &source_delay_a, const U &source_delay_b) const {
-      int i_delay_a = source_delay_a & PortMask;
-      int i_delay_b = source_delay_b & PortMask;
+    uint operator()(const uint &source_delay_a, const uint &source_delay_b) const {
+      uint i_delay_a = source_delay_a & PortMask;
+      uint i_delay_b = source_delay_b & PortMask;
         return (i_delay_b > i_delay_a) ? i_delay_b : i_delay_a;
     }
 };


### PR DESCRIPTION
After CUB fix, code was able to executed with CUDA 12.2, however under uncertain circumstances the templating of the MaxDelay functor was done incorrectly and CUDA errors were produced.
With strict typing now the functor works properly during simulation.