### PR TITLE
Better nested loop algoritm and kernel settings for NEST GPU

### DIFF
--- a/python/Potjans_2014/README.md
+++ b/python/Potjans_2014/README.md
@@ -1,16 +1,13 @@
-NEST GPU microcircuit
-=====================
+# NEST GPU microcircuit
 
 This is a NEST GPU implementation of the microcircuit model by Potjans and Diesmann [1]_.
 The network model represents four layers of cortex, L2/3, L4, L5, and L6, each consisting of a population of excitatory neurons and a population of inhibitory neurons.
 
-Citing this code
-################
+## Citing this code
 
 If you use this code, we ask you to cite the paper by Potjans and Diesmann [1]_ and the one by Bruno Golosio [2]_.
 
-File structure
-##############
+## File structure
 
 * [run_microcircuit.py](run_microcircuit.py): an example script to try out the microcircuit
 * [run_benchmark.py](run_benchmark.py): an example script for benchmarking purposes, adapted from [3]_
@@ -20,8 +17,7 @@ File structure
 * [stimulus_params.py](stimulus_params.py): parameters for optional external stimulation
 * [sim_params.py](sim_params.py): simulation parameters
 
-Running the simulation
-######################
+## Running the simulation
 
 By default, the variables ``N_scaling`` and ``K_scaling`` in ``network_params.py`` are set to
 `1.0` (i.e., the full-scale network). ``N_scaling`` adjusts the number of neurons and ``K_scaling`` adjusts the indegrees.
@@ -36,8 +32,7 @@ To run a simulation, simply use:
 The output will be saved in the ``data`` directory.
 
 
-Note on parameters
-##################
+## Note on parameters
 
 By default, the simulation uses external Poissonian input to excite all neuronal populations of the microcircuit, i.e., ``poisson_input': True`` in [network_params.py](network_params.py).
 If set to ``False``, the Poissonian input is turned off and compensated approximately by calculated direct current (DC) input.
@@ -48,8 +43,7 @@ Previous implementations used the same mean and standard deviation for all popul
 
 In NEST GPU we implemented the kernel parameter ``remove_conn_key``, which deletes, if ``True``, connection keys after havning organized them. This procedure is useful for optimizing GPU memory consumption, however, it does not allow to get the connections after calibration (the default is ``False``).
 
-Recommendations for benchmarking
-################################
+## Recommendations for benchmarking
 
 For benchmark simulations assessing network-construction and state-propagation times, some simulation parameters changing is recommented.
 You can update the parameters directly in the [run_benchmark.py](run_benchmark.py) script as follows:
@@ -85,8 +79,7 @@ using different seed for random number generation, storing all the data in a fol
 
    bash run_benchmark.sh
 
-Contributions to this NEST GPU microcircuit model implementation
-################################################################
+## Contributions to this NEST GPU microcircuit model implementation
 
 2023: revision of code and documentation by Jose Villamar and Gianmarco Tiddia [3]_
 
@@ -100,21 +93,19 @@ Current communicating author of the NEST version: Johanna Senk
 
 2016: first version implemented by Hendrik Rothe, Hannah Bos and Sacha van Albada
 
-Acknowledgments
-###############
+## Acknowledgments
 
 Funding for the PyNEST microcircuit: This project has received funding from the European Union Seventh Framework Programme ([FP7/2007-2013]) under grant agreement n° 604102 (Human Brain Project, HBP) and the European Union’s Horizon 2020 Framework Programme for Research and Innovation under Specific Grant Agreement No. 720270 (Human Brain Project SGA1) and No. 785907 (Human Brain Project SGA2).
 
 Funding for [1]_: This work was supported by the Helmholtz Alliance on Systems Biology; European Union (FACETS, grant 15879 and BrainScaleS, grant 269921); Deutsch-Israelische Projektkooperation (DIP, grant F1.2); Bundesministerium für Bildung und Forschung, Germany (BMBF, grant 01GQ0420 to BCCN Freiburg), and the Next-Generation Supercomputer Project of the Ministry of education, culture, sports, science and technology (MEXT), Japan. Funding to pay the Open Access publication charges for this article was provided by Research Center Juelich, a member of the Helmholtz Association.
 
-Other implementations of the microcircuit model
-###############################################
+## Other implementations of the microcircuit model
+
 A `SLI version <https://github.com/nest/nest-simulator/tree/master/examples/nest/Potjans_2014>`__  by David Dahmen, Tom Tetzlaff, and Sacha van Albada, based on the original version by Tobias Potjans and Markus Diesmann, is also part of the NEST code base as an example.
 
 A `PyNN version <https://github.com/NeuralEnsemble/PyNN/tree/master/examples/Potjans2014>`__ is part of the PyNN code base as an example.
 
-References
-##########
+## References
 
 .. [1]  Potjans TC. and Diesmann M. 2014. The cell-type specific cortical
         microcircuit: relating structure and activity in a full-scale spiking

--- a/python/Potjans_2014/README.md
+++ b/python/Potjans_2014/README.md
@@ -1,16 +1,16 @@
 # NEST GPU microcircuit
 
-This is a NEST GPU implementation of the microcircuit model by Potjans and Diesmann [1]_.
+This is a NEST GPU implementation of the microcircuit model by Potjans and Diesmann [1].
 The network model represents four layers of cortex, L2/3, L4, L5, and L6, each consisting of a population of excitatory neurons and a population of inhibitory neurons.
 
 ## Citing this code
 
-If you use this code, we ask you to cite the paper by Potjans and Diesmann [1]_ and the one by Bruno Golosio [2]_.
+If you use this code, we ask you to cite the paper by Potjans and Diesmann [1] and the one by Bruno Golosio [2].
 
 ## File structure
 
 * [run_microcircuit.py](run_microcircuit.py): an example script to try out the microcircuit
-* [run_benchmark.py](run_benchmark.py): an example script for benchmarking purposes, adapted from [3]_
+* [run_benchmark.py](run_benchmark.py): an example script for benchmarking purposes, adapted from [3]
 * [network.py](network.py): the main Network class with functions to build and simulate the network
 * [helpers.py](helpers.py): helper functions for network construction, simulation and evaluation
 * [network_params.py](network_params.py): network and neuron parameters
@@ -59,7 +59,7 @@ You can update the parameters directly in the [run_benchmark.py](run_benchmark.p
 
 Also network parameters can similarly be updated, as can be seen in [L99](run_benchmark.py#L99).
 
-The benchmarking scripts are adapted from [3]_. See also the [GitHub repository](https://github.com/gmtiddia/ngpu_dynamic_network_creation/tree/main/ngpu_microcircuit)
+The benchmarking scripts are adapted from [3]. See also the [GitHub repository](https://github.com/gmtiddia/ngpu_dynamic_network_creation/tree/main/ngpu_microcircuit)
 for a detailed description of the simulation files. To run the benchmarking script you should write:
 
 .. code-block:: bash
@@ -81,9 +81,9 @@ using different seed for random number generation, storing all the data in a fol
 
 ## Contributions to this NEST GPU microcircuit model implementation
 
-2023: revision of code and documentation by Jose Villamar and Gianmarco Tiddia [3]_
+2023: revision of code and documentation by Jose Villamar and Gianmarco Tiddia [3]
 
-2020: adapted for NEST GPU by Bruno Golosio [2]_
+2020: adapted for NEST GPU by Bruno Golosio [2]
 
 Current communicating author of the NEST version: Johanna Senk
 
@@ -97,7 +97,7 @@ Current communicating author of the NEST version: Johanna Senk
 
 Funding for the PyNEST microcircuit: This project has received funding from the European Union Seventh Framework Programme ([FP7/2007-2013]) under grant agreement n° 604102 (Human Brain Project, HBP) and the European Union’s Horizon 2020 Framework Programme for Research and Innovation under Specific Grant Agreement No. 720270 (Human Brain Project SGA1) and No. 785907 (Human Brain Project SGA2).
 
-Funding for [1]_: This work was supported by the Helmholtz Alliance on Systems Biology; European Union (FACETS, grant 15879 and BrainScaleS, grant 269921); Deutsch-Israelische Projektkooperation (DIP, grant F1.2); Bundesministerium für Bildung und Forschung, Germany (BMBF, grant 01GQ0420 to BCCN Freiburg), and the Next-Generation Supercomputer Project of the Ministry of education, culture, sports, science and technology (MEXT), Japan. Funding to pay the Open Access publication charges for this article was provided by Research Center Juelich, a member of the Helmholtz Association.
+Funding for [1]: This work was supported by the Helmholtz Alliance on Systems Biology; European Union (FACETS, grant 15879 and BrainScaleS, grant 269921); Deutsch-Israelische Projektkooperation (DIP, grant F1.2); Bundesministerium für Bildung und Forschung, Germany (BMBF, grant 01GQ0420 to BCCN Freiburg), and the Next-Generation Supercomputer Project of the Ministry of education, culture, sports, science and technology (MEXT), Japan. Funding to pay the Open Access publication charges for this article was provided by Research Center Juelich, a member of the Helmholtz Association.
 
 ## Other implementations of the microcircuit model
 
@@ -107,14 +107,14 @@ A [PyNN version](https://github.com/NeuralEnsemble/PyNN/tree/master/examples/Pot
 
 ## References
 
-.. [1]  Potjans TC. and Diesmann M. 2014. The cell-type specific cortical
+- [1]  Potjans TC. and Diesmann M. 2014. The cell-type specific cortical
         microcircuit: relating structure and activity in a full-scale spiking
-        network model. Cerebral Cortex. 24(3):785–806. DOI: `10.1093/cercor/bhs358 <https://doi.org/10.1093/cercor/bhs358>`__.
+        network model. Cerebral Cortex. 24(3):785–806. DOI: [10.1093/cercor/bhs358](https://doi.org/10.1093/cercor/bhs358).
 
-.. [2]  Golosio B., Tiddia G., De Luca C., Pastorelli E., Simula F. and Paolucci PS. 2021
+- [2]  Golosio B., Tiddia G., De Luca C., Pastorelli E., Simula F. and Paolucci PS. 2021
         Fast Simulations of Highly-Connected Spiking Cortical Models Using GPUs. 
-        Front. Comput. Neurosci. 15:627620. DOI: `10.3389/fncom.2021.627620 <https://doi.org/10.3389/fncom.2021.627620>`__.
+        Front. Comput. Neurosci. 15:627620. DOI: [10.3389/fncom.2021.627620](https://doi.org/10.3389/fncom.2021.627620).
 
-.. [3]  Golosio B., Villamar J., Tiddia G., Pastorelli E., Stapmanns J., Fanti V., Paolucci PS., Morrison A. and Senk J. 2023 
+- [3]  Golosio B., Villamar J., Tiddia G., Pastorelli E., Stapmanns J., Fanti V., Paolucci PS., Morrison A. and Senk J. 2023 
         Runtime Construction of Large-Scale Spiking Neuronal Network Models on GPU Devices. 
-        Applied Sciences; 13(17):9598. DOI: `10.3390/app13179598 <https://doi.org/10.3390/app13179598>`__.
+        Applied Sciences; 13(17):9598. DOI: [10.3390/app13179598](https://doi.org/10.3390/app13179598).

--- a/python/Potjans_2014/README.md
+++ b/python/Potjans_2014/README.md
@@ -46,6 +46,8 @@ In addition to this ongoing external drive, a thalamic stimulation or a stimulat
 The default random initialization of membrane voltages in this simulation uses population-specific means and standard deviations to reduce an initial activity burst in the network: ``'V_type': 'optimized'`` in [network_params.py](network_params.py).
 Previous implementations used the same mean and standard deviation for all populations, which is here achieved by setting ``'V_type': 'original'``.
 
+In NEST GPU we implemented the kernel parameter ``remove_conn_key``, which deletes, if ``True``, connection keys after havning organized them. This procedure is useful for optimizing GPU memory consumption, however, it does not allow to get the connections after calibration (the default is ``False``).
+
 Recommendations for benchmarking
 ################################
 
@@ -57,7 +59,8 @@ You can update the parameters directly in the [run_benchmark.py](run_benchmark.p
    sim_dict.update({
     't_presim': 0.1, # presimulation time equal to the duration of a single time step. This is needed to trigger the Calibration phase.
     't_sim': 10000., # the biological simulation time should be at least `10` s for measuring the state propagation time.
-    'rec_dev': [] # no recording devices.
+    'rec_dev': [], # no recording devices.
+    'nl_algo': 0, #BlockStep nested loop algorithm is the fastest for NVIDIA A100, but algorithm speed depends on the GPU card and the architecture.
    })
 
 Also network parameters can similarly be updated, as can be seen in [L99](run_benchmark.py#L99).

--- a/python/Potjans_2014/README.md
+++ b/python/Potjans_2014/README.md
@@ -59,7 +59,7 @@ You can update the parameters directly in the [run_benchmark.py](run_benchmark.p
 
 Also network parameters can similarly be updated, as can be seen in [L99](run_benchmark.py#L99).
 
-The benchmarking scripts are adapted from [3]_. See also the `GitHub repository <https://github.com/gmtiddia/ngpu_dynamic_network_creation/tree/main/ngpu_microcircuit>`__ 
+The benchmarking scripts are adapted from [3]_. See also the [GitHub repository](https://github.com/gmtiddia/ngpu_dynamic_network_creation/tree/main/ngpu_microcircuit)
 for a detailed description of the simulation files. To run the benchmarking script you should write:
 
 .. code-block:: bash
@@ -101,9 +101,9 @@ Funding for [1]_: This work was supported by the Helmholtz Alliance on Systems B
 
 ## Other implementations of the microcircuit model
 
-A `SLI version <https://github.com/nest/nest-simulator/tree/master/examples/nest/Potjans_2014>`__  by David Dahmen, Tom Tetzlaff, and Sacha van Albada, based on the original version by Tobias Potjans and Markus Diesmann, is also part of the NEST code base as an example.
+A [SLI version](https://github.com/nest/nest-simulator/tree/master/examples/nest/Potjans_2014)  by David Dahmen, Tom Tetzlaff, and Sacha van Albada, based on the original version by Tobias Potjans and Markus Diesmann, is also part of the NEST code base as an example.
 
-A `PyNN version <https://github.com/NeuralEnsemble/PyNN/tree/master/examples/Potjans2014>`__ is part of the PyNN code base as an example.
+A [PyNN version](https://github.com/NeuralEnsemble/PyNN/tree/master/examples/Potjans2014>) is part of the PyNN code base as an example.
 
 ## References
 

--- a/python/Potjans_2014/network.py
+++ b/python/Potjans_2014/network.py
@@ -78,16 +78,6 @@ class Network:
         # initialize NEST GPU
         self.__setup_ngpu()
 
-    def set_algo(self, algo_num: int):
-        """
-        Set Nested Loop algorithm.
-        Does nothing if NEST GPU version < 2.0.
-        """
-        if hasattr(ngpu, "SetNestedLoopAlgo"):
-            ngpu.SetNestedLoopAlgo(algo_num)
-        else:
-            print("Cannot set nested loop algorithm in NEST GPU version < 2.0")
-
     def create(self):
         """ Creates all network nodes.
 
@@ -291,16 +281,27 @@ class Network:
             print(message)
 
     def __setup_ngpu(self):
-        """ Initializes NEST GPU.
+        """ 
+        Initializes NEST GPU and sets the nested loop algorithm if NEST GPU version < 2.0.
 
         """
 
         # set seeds for random number generation
         master_seed = self.sim_dict['master_seed']
         ngpu.SetRandomSeed(master_seed)
-        ngpu.SetKernelStatus({'print_time': self.sim_dict['print_time'],
-                              'remove_conn_key': self.sim_dict['remove_conn_key']})
+        if('remove_conn_key' in ngpu.GetKernelStatus()):
+            ngpu.SetKernelStatus({'print_time': self.sim_dict['print_time'],
+                                  'remove_conn_key': self.sim_dict['remove_conn_key']})
+        else:
+            ngpu.SetKernelStatus({'print_time': self.sim_dict['print_time']})
+            print("Cannot set remove_conn_key in NEST GPU version < 2.0")
+            
         self.sim_resolution = self.sim_dict['sim_resolution']
+
+        if hasattr(ngpu, "SetNestedLoopAlgo"):
+            ngpu.SetNestedLoopAlgo(self.sim_dict['nl_algo'])
+        else:
+            print("Cannot set nested loop algorithm in NEST GPU version < 2.0")
 
     def __create_neuronal_populations(self):
         """ Creates the neuronal populations.

--- a/python/Potjans_2014/run_benchmark.py
+++ b/python/Potjans_2014/run_benchmark.py
@@ -94,7 +94,8 @@ sim_dict.update({
     't_presim': 0.1,
     't_sim': 10000.,
     'rec_dev': [],
-    'master_seed': args.seed})
+    'master_seed': args.seed,
+    'nl_algo': args.algo})
 
 net_dict.update({
     'N_scaling': 1.,
@@ -103,7 +104,6 @@ net_dict.update({
     'V0_type': 'optimized'})
 
 net = network.Network(sim_dict, net_dict, stim_dict)
-net.set_algo(args.algo)
 time_network = perf_counter_ns()
 
 net.create()

--- a/python/Potjans_2014/run_microcircuit.py
+++ b/python/Potjans_2014/run_microcircuit.py
@@ -52,8 +52,6 @@ time_start = time.time()
 # transient has passed.
 
 net = network.Network(sim_dict, net_dict, stim_dict)
-# set the fastest nested loop algorithm (i.e., BlockStep)
-net.set_algo(0)
 time_network = time.time()
 
 net.create()

--- a/python/Potjans_2014/sim_params.py
+++ b/python/Potjans_2014/sim_params.py
@@ -49,6 +49,8 @@ sim_dict = {
     'master_seed': 12349, #55,
     # optimizes GPU memory by removing unnecessary connection keys
     'remove_conn_key': False,
+    # set nested loop algorithm {0: "BlockStep", 1: "CumulSum", 2: "Simple", 3: "ParallelInner", 4: "ParallelOuter", 5: "Frame1D", 6: "Frame2D", 7: "Smart1D", 8: "Smart2D"}
+    'nl_algo': 0,
     # recording interval of the membrane potential (in ms)
     'rec_V_int': 1.0,
     # if True, data will be overwritten,

--- a/python/Potjans_2014/sim_params.templ
+++ b/python/Potjans_2014/sim_params.templ
@@ -48,6 +48,8 @@ sim_dict = {
     'master_seed': __seed__, #55,
     # optimizes GPU memory by removing unnecessary connection keys
     'remove_conn_key': False,
+    # set nested loop algorithm {0: "BlockStep", 1: "CumulSum", 2: "Simple", 3: "ParallelInner", 4: "ParallelOuter", 5: "Frame1D", 6: "Frame2D", 7: "Smart1D", 8: "Smart2D"}
+    'nl_algo': 0,
     # recording interval of the membrane potential (in ms)
     'rec_V_int': 1.0,
     # if True, data will be overwritten,


### PR DESCRIPTION
I moved the nested loop algorithm parameters in the sim_params.py file, setting the default to 0. I updated the documentation for running the model, especially for benchmarking.

Regarding PR #90, I added in the documentation some details on "remove_conn_key" key of the NEST GPU kernel and added a control to avoid raising an error for older versions of NEST GPU.

I've also made general improvements to the model documentation.