### PR TITLE
Added NVTX profile ranges through toggleable macros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ set( with-includes OFF CACHE STRING "Add additional include paths [default=OFF].
 set( with-defines OFF CACHE STRING "Additional defines, e.g. '-DXYZ=1' [default=OFF]. Separate multiple defines by ';'." )
 set( with-max-rreg-count "55" CACHE STRING "Set a maximum amount of register used when compiling [default=55]. Separate multiple flags by ';'." )
 set( with-ptxas-options OFF CACHE STRING "Options for ptxas compiling [default=OFF]. Separate multiple flags by ';'." )
+set( with-nvtx OFF CACHE STRING "Enable compilation with NVTX ranges." )
 
 # generic build configuration
 set( with-version-suffix OFF CACHE STRING "Set a user defined version suffix [default='']." )
@@ -130,6 +131,7 @@ nest_process_with_optimize()
 nest_process_with_debug()
 nest_process_with_warning()
 nestgpu_post_process_compile_flags()
+nestgpu_process_with_nvtx()
 
 nest_process_version_suffix()
 

--- a/cmake/ProcessOptions.cmake
+++ b/cmake/ProcessOptions.cmake
@@ -209,6 +209,14 @@ function( NESTGPU_POST_PROCESS_COMPILE_FLAGS )
 endfunction()
 
 
+function( NESTGPU_PROCESS_WITH_NVTX )
+  set( HAVE_NVTX OFF PARENT_SCOPE )
+  if ( with-nvtx )
+    set( HAVE_NVTX ON PARENT_SCOPE )
+  endif()
+endfunction()
+
+
 function( NEST_PROCESS_VERSION_SUFFIX )
   if ( with-version-suffix )
     foreach ( flag ${with-version-suffix} )

--- a/libnestutil/config.h.in
+++ b/libnestutil/config.h.in
@@ -48,6 +48,9 @@
 /* Define to 1 if you have the <unistd.h> header file. */
 #cmakedefine HAVE_UNISTD_H 1
 
+/* Define to 1 for compiling with nvtx ranges. */
+#cmakedefine HAVE_NVTX 1
+
 /* Version number of package */
 #define VERSION @NEST_GPU_VERSION_STRING@
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,6 +75,7 @@ nestgpu_C.h
 neuron_models.h
 ngpu_exception.h
 node_group.h
+nvtx_macros.h
 parrot_neuron.h
 poiss_gen.h
 poiss_gen_variables.h

--- a/src/nvtx_macros.h
+++ b/src/nvtx_macros.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <config.h>
+
+#ifdef HAVE_NVTX
+#include <cuda_profiler_api.h>
+#include <nvtx3/nvToolsExt.h>
+
+const uint32_t colors[] = { 0xff00ff00, 0xff0000ff, 0xffffff00, 0xffff00ff, 0xff00ffff, 0xffff0000, 0xffffffff };
+const int num_colors = sizeof( colors ) / sizeof( uint32_t );
+
+#define PUSH_RANGE( name, cid )                        \
+  {                                                    \
+    int color_id = cid;                                \
+    color_id = color_id % num_colors;                  \
+    nvtxEventAttributes_t eventAttrib = { 0 };         \
+    eventAttrib.version = NVTX_VERSION;                \
+    eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;  \
+    eventAttrib.colorType = NVTX_COLOR_ARGB;           \
+    eventAttrib.color = colors[ color_id ];            \
+    eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII; \
+    eventAttrib.message.ascii = name;                  \
+    nvtxRangePushEx( &eventAttrib );                   \
+  }
+#define POP_RANGE nvtxRangePop();
+#define PROFILER_START cudaProfilerStart();
+#define PROFILER_STOP cudaProfilerStop();
+#else
+#define PUSH_RANGE( name, cid )
+#define POP_RANGE
+#define PROFILER_START
+#define PROFILER_STOP
+#endif


### PR DESCRIPTION
This pull request adds support for NVTX profile ranges macros.
This can be enabled through CMake with -Dwith-nvtx=ON, it is disabled by default.
When disabled the macros perform no operation hence represent no computational overhead.