### PR TITLE
Fix MPI error for simulations using point-to-point communication 

### DIFF
--- a/pythonlib/nestgpu.py
+++ b/pythonlib/nestgpu.py
@@ -1577,7 +1577,13 @@ NESTGPU_ConnectMpiInit = _nestgpu.NESTGPU_ConnectMpiInit
 NESTGPU_ConnectMpiInit.restype = ctypes.c_int
 def ConnectMpiInit():
     "Initialize MPI connectivity"
-    ret = NESTGPU_ConnectMpiInit()
+    argc = len(sys.argv)
+    c_argc = ctypes.c_int(argc)
+    c_argv = (ctypes.c_char_p * (argc + 1))()
+    for i, arg in enumerate(sys.argv):
+        c_argv[i] = arg.encode("utf-8", "strict") + b"\0"
+    c_argv[argc] = None
+    ret = NESTGPU_ConnectMpiInit(c_argc, c_argv)
     if GetErrorCode() != 0:
         raise ValueError(GetErrorMessage())
     return ret

--- a/src/connect.h
+++ b/src/connect.h
@@ -4425,6 +4425,7 @@ ConnectionTemplate< ConnKeyT, ConnStructT >::freeConnRandomGenerator()
       {
 	if (conn_random_generator_[ i_host ][ j_host ] != nullptr) { 
 	  CURAND_CALL( curandDestroyGenerator( conn_random_generator_[ i_host ][ j_host ] ) );
+    conn_random_generator_[ i_host ][ j_host ] = nullptr;
 	}
       }
     }

--- a/src/mpi_comm.cu
+++ b/src/mpi_comm.cu
@@ -348,7 +348,7 @@ NESTGPU::RecvSpikeFromRemote()
 }
 
 int
-NESTGPU::ConnectMpiInit()
+NESTGPU::ConnectMpiInit( int argc, char** argv )
 {
 #ifdef HAVE_MPI
   CheckUncalibrated( "MPI connections cannot be initialized after calibration" );
@@ -356,7 +356,8 @@ NESTGPU::ConnectMpiInit()
   MPI_Initialized( &initialized );
   if ( !initialized )
   {
-    MPI_Init( nullptr, nullptr );
+    int provided_thread_level;
+    MPI_Init_thread( &argc, &argv, MPI_THREAD_FUNNELED, &provided_thread_level );
   }
   int n_hosts;
   int this_host;

--- a/src/nestgpu.h
+++ b/src/nestgpu.h
@@ -628,7 +628,7 @@ public:
 
   int PrintTimers(int verbosity_level = 5);
 
-  int ConnectMpiInit();
+  int ConnectMpiInit( int argc, char** argv );
 
   int FakeConnectMpiInit(int n_hosts, int this_host);
 

--- a/src/nestgpu_C.cpp
+++ b/src/nestgpu_C.cpp
@@ -793,12 +793,12 @@ extern "C"
   }
 
   int
-  NESTGPU_ConnectMpiInit()
+  NESTGPU_ConnectMpiInit(int argc, char** argv)
   {
     int ret = 0;
     BEGIN_ERR_PROP
     {
-      ret = NESTGPU_instance->ConnectMpiInit();
+      ret = NESTGPU_instance->ConnectMpiInit( argc, argv );
     }
     END_ERR_PROP return ret;
   }

--- a/src/nestgpu_C.h
+++ b/src/nestgpu_C.h
@@ -150,7 +150,7 @@ extern "C"
 
   int NESTGPU_PrintTimers();
 
-  int NESTGPU_ConnectMpiInit();
+  int NESTGPU_ConnectMpiInit( int argc, char** argv );
   
   int NESTGPU_FakeConnectMpiInit(int n_hosts, int this_host);
 


### PR DESCRIPTION
This PR solves the double free or corruption error on cuRAND generator when performing simulations with point-to-point communications on 2.0 version. 

Additionally, it adds the arguments to MPI Init, as done [in this commit of @JoseJVS](https://github.com/JoseJVS/nest-gpu/commit/16be06c4cd9d2f29e2a2df383a2f4a3390d769e1).

Spike times checked performing a MAM simulation and comparing to mpi_com (last commit: da2a46345ebcd57fc494669f26d34d8e9dde65d7) using the same seed.