### PR TITLE
Documentation improvement: description of kernel parameters and randomness in NEST GPU

### DIFF
--- a/doc/htmldoc/guides/index.rst
+++ b/doc/htmldoc/guides/index.rst
@@ -8,6 +8,8 @@ Here you can find details on some topics about NEST GPU:
 
     differences_nest-gpu_nest
     connectivity_concepts
+    randomness_in_nestgpu_simulations
+    kernel_parameters
     implement_new_neuron_models
     how_to_record_spikes
     multigpu_simulations

--- a/doc/htmldoc/guides/kernel_parameters.rst
+++ b/doc/htmldoc/guides/kernel_parameters.rst
@@ -7,7 +7,9 @@ NEST GPU provides a set of configurable kernel parameters that control the globa
 
 The parameters are divided into three categories based on their data type:
 - :ref:`kernel-float-parameters`
+
 - :ref:`kernel-int-parameters`
+
 - :ref:`kernel-bool-parameters`
 
 ---
@@ -54,7 +56,7 @@ Integer parameters manage seed generation, verbosity, bit-width constraints for 
    * - Parameter Name
      - Description
    * - ``rnd_seed``
-     - Base random number generator (RNG) seed for stochastic processes and network initialization as mentioned in :doc:`random_number_seed`.
+     - Base random number generator (RNG) seed for stochastic processes and network initialization as mentioned in :ref:`random_number_seed`.
    * - ``verbosity_level``
      - Controls the amount of logging information and runtime messages printed to standard output.
    * - ``max_spike_buffer_size``

--- a/doc/htmldoc/guides/kernel_parameters.rst
+++ b/doc/htmldoc/guides/kernel_parameters.rst
@@ -5,108 +5,163 @@ NEST GPU kernel parameters
 
 NEST GPU provides a set of configurable kernel parameters that control the global simulation state, performance tuning, memory allocation, buffer sizes, and communication behavior across GPU and MPI nodes.
 
-The parameters are divided into three categories based on their data type:
+To better guide users, these parameters are divided into two categories based on their relevance and usage frequency:
 
-- :ref:`kernel-float-parameters`
+- :ref:`kernel-general-parameters`: Common parameters that standard users frequently adjust for their simulations.
 
-- :ref:`kernel-int-parameters`
-
-- :ref:`kernel-bool-parameters`
+- :ref:`kernel-advanced-parameters`: Low-level, internal, or optimization parameters that are typically managed by advanced developers and are best left at their default values.
 
 ---
 
-.. _kernel-float-parameters:
+.. _kernel-general-parameters:
 
-Floating-Point Parameters
--------------------------
+General Parameters
+------------------
 
-The following parameters accept floating-point values and typically regulate time resolution, integration steps, and scaling factors.
+These parameters are commonly accessed and modified by standard users to control basic simulation settings, output behavior, and stochastic properties.
 
 .. list-table::
-   :widths: 30 70
+   :widths: 25 15 60
    :header-rows: 1
 
    * - Parameter Name
+     - Type
      - Description
    * - ``time_resolution``
+     - float
      - Simulation time step (resolution) :math:`h` in milliseconds.
+   * - ``rnd_seed``
+     - int
+     - Base random number generator (RNG) seed for stochastic processes and network initialization as mentioned in :ref:`random_number_seed`.
+   * - ``min_allowed_delay``
+     - float
+     - Minimum allowed synaptic delay in the network (typically bounded by the simulation resolution).
+   * - ``verbosity_level``
+     - int
+     - Controls the amount of logging information and runtime messages printed to standard output.
+   * - ``print_time``
+     - bool
+     - Enables or disables periodic printing of the simulation progress (current simulation time) to stdout.
+
+---
+
+.. _kernel-advanced-parameters:
+
+Advanced Parameters
+-------------------
+
+These parameters regulate fine-grained memory allocation, buffer capacities, hardware bit-widths, and MPI communication strategies. Modifying them incorrectly may affect simulation stability or performance.
+
+.. list-table::
+   :widths: 25 15 60
+   :header-rows: 1
+
+   * - Parameter Name
+     - Type
+     - Description
    * - ``max_spike_num_fact``
+     - float
      - Scaling factor used to allocate memory buffers for spikes on the GPU dynamically.
    * - ``max_spike_per_host_fact``
+     - float
      - Safety factor for estimating the maximum number of spikes handled per host/node.
    * - ``max_remote_spike_num_fact``
+     - float
      - Scaling factor for remote spike communication buffers across MPI ranks.
-   * - ``min_allowed_delay``
-     - Minimum allowed synaptic delay in the network (typically bounded by the simulation resolution).
    * - ``use_all_source_node_fact``
+     - float
      - Factor regulating memory allocation strategies when handling all-to-all or dense source-node mappings.
-
----
-
-.. _kernel-int-parameters:
-
-Integer Parameters
-------------------
-
-Integer parameters manage seed generation, verbosity, bit-width constraints for hardware/data compression mapping, and algorithmic choices.
-
-.. list-table::
-   :widths: 30 70
-   :header-rows: 1
-
-   * - Parameter Name
-     - Description
-   * - ``rnd_seed``
-     - Base random number generator (RNG) seed for stochastic processes and network initialization as mentioned in :ref:`random_number_seed`.
-   * - ``verbosity_level``
-     - Controls the amount of logging information and runtime messages printed to standard output.
    * - ``max_spike_buffer_size``
+     - int
      - Maximum capacity of the spike buffers allocated during simulation.
    * - ``max_node_n_bits``
+     - int
      - Bit-width allocated for encoding node identifiers (IDs) in data structures.
    * - ``max_syn_n_bits``
+     - int
      - Bit-width allocated for synapse identification and indexing.
    * - ``max_delay_n_bits``
+     - int
      - Bit-width allocated for representing discrete synaptic delays.
    * - ``conn_struct_type``
+     - int
      - Selects the structural representation format for network connectivity.
    * - ``spike_buffer_algo``
-     - Selects the underlying algorithm used for managing and sorting spike buffers.
-
----
-
-.. _kernel-bool-parameters:
-
-Boolean Parameters
-------------------
-
-Boolean flags (enabled/disabled) used to toggle diagnostic checks, debugging outputs, performance optimizations, and MPI communication strategies.
-
-.. list-table::
-   :widths: 30 70
-   :header-rows: 1
-
-   * - Parameter Name
-     - Description
-   * - ``print_time``
-     - Enables or disables periodic printing of the simulation progress (current simulation time) to stdout.
+     - int
+     - Selects the underlying algorithm used for managing and sorting spike buffers as listed in :ref:`spike_buffer_algorithms`.
    * - ``remove_conn_key``
+     - bool
      - If enabled, removes connection keys to optimize memory footprint after initialization.
    * - ``remote_spike_mul``
+     - bool
      - Multiplier/modifier policy for remote spike exchange optimization across MPI processes.
    * - ``check_node_maps``
+     - bool
      - Enables rigorous consistency checks on node mapping structures between host and device.
    * - ``mpi_bitpack``
+     - bool
      - Enables bitpacking techniques for MPI communication to reduce network traffic bandwidth.
    * - ``max_n_ports_warning``
+     - bool
      - Toggles warning messages when approaching or exceeding the maximum number of structural ports.
    * - ``first_out_conn_in_device``
+     - bool
      - Optimization flag determining placement of the first outgoing connection structures within device memory.
    * - ``have_n_out_conn``
+     - bool
      - Flag indicating whether nodes track the total count of outgoing connections explicitly.
    * - ``delete_remote_node_map``
+     - bool
      - Frees remote node mapping data structures from memory once they are no longer required.
    * - ``delete_image_node_map``
+     - bool
      - Frees image node map structures to reclaim device/host memory post-setup.
 
 
+
+.. _spike_buffer_algorithms:
+
+Spike buffer algorithms
+-----------------------
+
+When constructing large-scale spiking neural networks, NEST GPU executes 
+intensive iteration patterns over populations and synapses. 
+To optimize performance and maximize hardware utilization across different
+network topologies and densities, NEST GPU implements several **nested loop algorithms**.
+These algorithms dictate how the iteration spaces (loops over source and target neurons)
+are parallelized and mapped onto the GPU threads.
+
+The available algorithms, which can be selected via configuration scripts, include:
+
+.. list-table::
+   :widths: 20 80
+   :header-rows: 1
+
+   * - ID & Name
+     - Description
+   * - **0: BlockStep**
+     - Divides the iteration space into blocks, stepping through segments to balance the workload across GPU threads.
+   * - **1: CumulSum**
+     - Utilizes prefix-sum (*scan*) operations to compute memory offsets dynamically, preventing race conditions during parallel construction.
+   * - **2: Simple**
+     - A straightforward, baseline implementation with minimal optimization. Useful primarily for debugging or very small networks where advanced overhead is unnecessary.
+   * - **3: ParallelInner**
+     - Parallelizes the innermost loop of the connection generation routine.
+   * - **4: ParallelOuter**
+     - Parallelizes the outermost loop of the connection generation routine, often preferred when dealing with large source populations.
+   * - **5: Frame1D**
+     - Subdivides the network space into 1D spatial frames to enhance memory locality and coalescing during execution.
+   * - **6: Frame2D**
+     - Extends spatial frame decomposition into 2D grids, ideal for topologically structured or layered 2D neural sheets.
+   * - **7: Smart1D**
+     - An adaptive, heuristic-driven 1D algorithm that automatically optimizes thread mapping based on network density and population size.
+   * - **8: Smart2D**
+     - An adaptive, heuristic-driven 2D algorithm designed to dynamically select the best spatial mapping strategy for complex 2D network topographies.
+
+The default choice for the ``spike_buffer_algo`` parameter is 0, i.e., the BlockStep algorithm. 
+This was verified to be the most efficient algorithm in several large-scale simulations :footcite:p:`Golosio2023`.
+
+References
+----------
+
+.. footbibliography::

--- a/doc/htmldoc/guides/kernel_parameters.rst
+++ b/doc/htmldoc/guides/kernel_parameters.rst
@@ -134,28 +134,38 @@ are parallelized and mapped onto the GPU threads.
 The available algorithms, which can be selected via configuration scripts, include:
 
 .. list-table::
-   :widths: 20 80
+   :widths: 5 25 70
    :header-rows: 1
 
-   * - ID & Name
+   * - ID
+     - Name
      - Description
-   * - **0: BlockStep**
+   * - **0**
+     - **BlockStep**
      - Divides the iteration space into blocks, stepping through segments to balance the workload across GPU threads.
-   * - **1: CumulSum**
+   * - **1**
+     - **CumulSum**
      - Utilizes prefix-sum (*scan*) operations to compute memory offsets dynamically, preventing race conditions during parallel construction.
-   * - **2: Simple**
+   * - **2**
+     - **Simple**
      - A straightforward, baseline implementation with minimal optimization. Useful primarily for debugging or very small networks where advanced overhead is unnecessary.
-   * - **3: ParallelInner**
+   * - **3**
+     - **ParallelInner**
      - Parallelizes the innermost loop of the connection generation routine.
-   * - **4: ParallelOuter**
+   * - **4**
+     - **ParallelOuter**
      - Parallelizes the outermost loop of the connection generation routine, often preferred when dealing with large source populations.
-   * - **5: Frame1D**
+   * - **5**
+     - **Frame1D**
      - Subdivides the network space into 1D spatial frames to enhance memory locality and coalescing during execution.
-   * - **6: Frame2D**
+   * - **6**
+     - **Frame2D**
      - Extends spatial frame decomposition into 2D grids, ideal for topologically structured or layered 2D neural sheets.
-   * - **7: Smart1D**
+   * - **7**
+     - **Smart1D**
      - An adaptive, heuristic-driven 1D algorithm that automatically optimizes thread mapping based on network density and population size.
-   * - **8: Smart2D**
+   * - **8**
+     - **Smart2D**
      - An adaptive, heuristic-driven 2D algorithm designed to dynamically select the best spatial mapping strategy for complex 2D network topographies.
 
 The default choice for the ``spike_buffer_algo`` parameter is 0, i.e., the BlockStep algorithm. 

--- a/doc/htmldoc/guides/kernel_parameters.rst
+++ b/doc/htmldoc/guides/kernel_parameters.rst
@@ -1,11 +1,12 @@
 .. _kernel_parameters:
 
-NEST GPU Kernel parameters
+NEST GPU kernel parameters
 ==========================
 
 NEST GPU provides a set of configurable kernel parameters that control the global simulation state, performance tuning, memory allocation, buffer sizes, and communication behavior across GPU and MPI nodes.
 
 The parameters are divided into three categories based on their data type:
+
 - :ref:`kernel-float-parameters`
 
 - :ref:`kernel-int-parameters`

--- a/doc/htmldoc/guides/kernel_parameters.rst
+++ b/doc/htmldoc/guides/kernel_parameters.rst
@@ -3,3 +3,107 @@
 NEST GPU Kernel parameters
 ==========================
 
+NEST GPU provides a set of configurable kernel parameters that control the global simulation state, performance tuning, memory allocation, buffer sizes, and communication behavior across GPU and MPI nodes.
+
+The parameters are divided into three categories based on their data type:
+- :ref:`kernel-float-parameters`
+- :ref:`kernel-int-parameters`
+- :ref:`kernel-bool-parameters`
+
+---
+
+.. _kernel-float-parameters:
+
+Floating-Point Parameters
+-------------------------
+
+The following parameters accept floating-point values and typically regulate time resolution, integration steps, and scaling factors.
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Parameter Name
+     - Description
+   * - ``time_resolution``
+     - Simulation time step (resolution) :math:`h` in milliseconds.
+   * - ``max_spike_num_fact``
+     - Scaling factor used to allocate memory buffers for spikes on the GPU dynamically.
+   * - ``max_spike_per_host_fact``
+     - Safety factor for estimating the maximum number of spikes handled per host/node.
+   * - ``max_remote_spike_num_fact``
+     - Scaling factor for remote spike communication buffers across MPI ranks.
+   * - ``min_allowed_delay``
+     - Minimum allowed synaptic delay in the network (typically bounded by the simulation resolution).
+   * - ``use_all_source_node_fact``
+     - Factor regulating memory allocation strategies when handling all-to-all or dense source-node mappings.
+
+---
+
+.. _kernel-int-parameters:
+
+Integer Parameters
+------------------
+
+Integer parameters manage seed generation, verbosity, bit-width constraints for hardware/data compression mapping, and algorithmic choices.
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Parameter Name
+     - Description
+   * - ``rnd_seed``
+     - Base random number generator (RNG) seed for stochastic processes and network initialization as mentioned in :doc:`random_number_seed`.
+   * - ``verbosity_level``
+     - Controls the amount of logging information and runtime messages printed to standard output.
+   * - ``max_spike_buffer_size``
+     - Maximum capacity of the spike buffers allocated during simulation.
+   * - ``max_node_n_bits``
+     - Bit-width allocated for encoding node identifiers (IDs) in data structures.
+   * - ``max_syn_n_bits``
+     - Bit-width allocated for synapse identification and indexing.
+   * - ``max_delay_n_bits``
+     - Bit-width allocated for representing discrete synaptic delays.
+   * - ``conn_struct_type``
+     - Selects the structural representation format for network connectivity.
+   * - ``spike_buffer_algo``
+     - Selects the underlying algorithm used for managing and sorting spike buffers.
+
+---
+
+.. _kernel-bool-parameters:
+
+Boolean Parameters
+------------------
+
+Boolean flags (enabled/disabled) used to toggle diagnostic checks, debugging outputs, performance optimizations, and MPI communication strategies.
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Parameter Name
+     - Description
+   * - ``print_time``
+     - Enables or disables periodic printing of the simulation progress (current simulation time) to stdout.
+   * - ``remove_conn_key``
+     - If enabled, removes connection keys to optimize memory footprint after initialization.
+   * - ``remote_spike_mul``
+     - Multiplier/modifier policy for remote spike exchange optimization across MPI processes.
+   * - ``check_node_maps``
+     - Enables rigorous consistency checks on node mapping structures between host and device.
+   * - ``mpi_bitpack``
+     - Enables bitpacking techniques for MPI communication to reduce network traffic bandwidth.
+   * - ``max_n_ports_warning``
+     - Toggles warning messages when approaching or exceeding the maximum number of structural ports.
+   * - ``first_out_conn_in_device``
+     - Optimization flag determining placement of the first outgoing connection structures within device memory.
+   * - ``have_n_out_conn``
+     - Flag indicating whether nodes track the total count of outgoing connections explicitly.
+   * - ``delete_remote_node_map``
+     - Frees remote node mapping data structures from memory once they are no longer required.
+   * - ``delete_image_node_map``
+     - Frees image node map structures to reclaim device/host memory post-setup.
+
+

--- a/doc/htmldoc/guides/kernel_parameters.rst
+++ b/doc/htmldoc/guides/kernel_parameters.rst
@@ -1,0 +1,5 @@
+.. _kernel_parameters:
+
+NEST GPU Kernel parameters
+==========================
+

--- a/doc/htmldoc/guides/randomness_in_nestgpu_simulations.rst
+++ b/doc/htmldoc/guides/randomness_in_nestgpu_simulations.rst
@@ -7,13 +7,17 @@ Randomness in NEST GPU Simulations
 As in NEST, random numbers are used in several occasions for neural network creation, such
 as the randomization of node and connection parameters and when stochastic input or stochastic 
 connection rules are employed in the simulation. NEST GPU uses random generators from the 
-`curand <https://docs.nvidia.com/cuda/curand/index.html>`_ library of CUDA to obtain random numbers following different distributions.
+`curand <https://docs.nvidia.com/cuda/curand/index.html>`_ library of CUDA to obtain random
+numbers following different distributions.
+
+.. _random_number_seed:
 
 Random numbers for simulation
 =============================
 
 Similar to the CPU version of NEST, the randomness for a simulation can be set
-throughout a master seed, which is part of the kernel parameters. This is used
+throughout a master seed, which is part of the kernel parameters (see 
+:doc:`kernel_parameters` for more information in this regard). This is used
 both for the probabilistic connection rules, the creation of parameter 
 distributions as described below and the stochastic input generation. It can be
 set as follows:
@@ -22,6 +26,8 @@ set as follows:
 
    nestgpu.SetKernelStatus("rnd_seed", 1234)
 
+
+.. _random_number_params:
 
 Random numbers for network parameters
 =====================================
@@ -35,8 +41,8 @@ how the distribution can be used to randomize the membrane potential of a neuron
 
 .. code-block:: python
 
-   n=ngpu.Create('aeif_cond_beta', 10000, 3)
-   ngpu.SetStatus(n, 'V_m', {'distribution':'normal','mu':1.0, 'sigma':0.5})
+   n=nestgpu.Create('aeif_cond_beta', 10000, 3)
+   nestgpu.SetStatus(n, 'V_m', {'distribution':'normal','mu':1.0, 'sigma':0.5})
 
 
 Normal clipped distribution
@@ -48,8 +54,8 @@ alongside mean and standard deviation, as shown in an example similar to the one
 
 .. code-block:: python
 
-   n=ngpu.Create('aeif_cond_beta', 10000, 3)
-   ngpu.SetStatus(n, 'V_m', {'distribution':'normal_clipped','mu':1.0, 'sigma':0.5, 'low':0.1, 'high':2.0})
+   n=nestgpu.Create('aeif_cond_beta', 10000, 3)
+   nestgpu.SetStatus(n, 'V_m', {'distribution':'normal_clipped','mu':1.0, 'sigma':0.5, 'low':0.1, 'high':2.0})
 
 
 Lognormal clipped distribution
@@ -68,9 +74,9 @@ as synaptic weights and delays.
    low = 0.1
    high = 100
 
-   neuron1 = ngpu.Create("aeif_cond_beta_multisynapse", 5000)
-   neuron2 = ngpu.Create("aeif_cond_beta_multisynapse", 5000)
-   ngpu.Connect(neuron1, neuron2, {'rule': 'one_to_one'}, {'delay': {'distribution': 'lognormal_clipped', 'mu': mu, 'sigma':sigma, 'low': low, 'high': high},                   
+   neuron1 = nestgpu.Create("aeif_cond_beta_multisynapse", 5000)
+   neuron2 = nestgpu.Create("aeif_cond_beta_multisynapse", 5000)
+   nestgpu.Connect(neuron1, neuron2, {'rule': 'one_to_one'}, {'delay': {'distribution': 'lognormal_clipped', 'mu': mu, 'sigma':sigma, 'low': low, 'high': high},                   
                                                          'weight': {'distribution': 'lognormal_clipped', 'mu': mu, 'sigma': sigma, 'low': low, 'high': high}})
 
 

--- a/doc/htmldoc/guides/randomness_in_nestgpu_simulations.rst
+++ b/doc/htmldoc/guides/randomness_in_nestgpu_simulations.rst
@@ -1,7 +1,7 @@
 .. _randomness_in_nestgpu_simulations:
 
 ==================================
-Randomness in NEST GPU Simulations
+Randomness in NEST GPU simulations
 ==================================
 
 As in NEST, random numbers are used in several occasions for neural network creation, such

--- a/doc/htmldoc/guides/randomness_in_nestgpu_simulations.rst
+++ b/doc/htmldoc/guides/randomness_in_nestgpu_simulations.rst
@@ -1,13 +1,30 @@
 .. _randomness_in_nestgpu_simulations:
 
+==================================
 Randomness in NEST GPU Simulations
 ==================================
 
-As in NEST, random numbers are used in several occasions for neural network simulations, such
-as the randomization of node and connection parameters. NEST GPU uses random generators from
-the curand library of CUDA to obtain random numbers following different distributions.
+As in NEST, random numbers are used in several occasions for neural network creation, such
+as the randomization of node and connection parameters and when stochastic input or stochastic 
+connection rules are employed in the simulation. NEST GPU uses random generators from the 
+`curand <https://docs.nvidia.com/cuda/curand/index.html>`_ library of CUDA to obtain random numbers following different distributions.
 
-The following describes the distributions that are implemented in NEST GPU.
+Random numbers for simulation
+=============================
+
+Similar to the CPU version of NEST, the randomness for a simulation can be set
+throughout a master seed, which is part of the kernel parameters. This is used
+both for the probabilistic connection rules, the creation of parameter 
+distributions as described below and the stochastic input generation. It can be
+set as follows:
+
+.. code-block:: python
+
+   nestgpu.SetKernelStatus("rnd_seed", 1234)
+
+
+Random numbers for network parameters
+=====================================
 
 Normal distribution
 -------------------
@@ -65,5 +82,3 @@ passing a Python array to the parameter. This way, also the
 distributions implemented in Python scientific libraries can
 be used for simulation. The array can be simply passed when
 setting the node or connection parameter.
-
-

--- a/doc/htmldoc/guides/randomness_in_nestgpu_simulations.rst
+++ b/doc/htmldoc/guides/randomness_in_nestgpu_simulations.rst
@@ -1,0 +1,69 @@
+.. _randomness_in_nestgpu_simulations:
+
+Randomness in NEST GPU Simulations
+==================================
+
+As in NEST, random numbers are used in several occasions for neural network simulations, such
+as the randomization of node and connection parameters. NEST GPU uses random generators from
+the curand library of CUDA to obtain random numbers following different distributions.
+
+The following describes the distributions that are implemented in NEST GPU.
+
+Normal distribution
+-------------------
+
+Draws a normal distribution given a mean (``mu``) and standard deviation (``sigma``).
+Values for mean and standard deviation must be always specified. The following example shows
+how the distribution can be used to randomize the membrane potential of a neuron population.
+
+.. code-block:: python
+
+   n=ngpu.Create('aeif_cond_beta', 10000, 3)
+   ngpu.SetStatus(n, 'V_m', {'distribution':'normal','mu':1.0, 'sigma':0.5})
+
+
+Normal clipped distribution
+---------------------------
+
+Draws a normal clipped distribution given a mean (``mu``) and standard deviation (``sigma``).
+The distribution is clipped on the range [low, high], where ``low`` and ``high`` are specified
+alongside mean and standard deviation, as shown in an example similar to the one above.
+
+.. code-block:: python
+
+   n=ngpu.Create('aeif_cond_beta', 10000, 3)
+   ngpu.SetStatus(n, 'V_m', {'distribution':'normal_clipped','mu':1.0, 'sigma':0.5, 'low':0.1, 'high':2.0})
+
+
+Lognormal clipped distribution
+------------------------------
+
+Draws a lognormal clipped distribution with mean ``mu`` and standard deviation ``sigma``,
+where the mean and standard deviation are of the underlying normal distribution. This is 
+the same approach used in Python libraries such as Numpy, and also in the CPU version of
+NEST. The following code shows how to lognormally distribute connection parameters such 
+as synaptic weights and delays.
+
+.. code-block:: python
+
+   mu = 10.0
+   sigma = 5.0
+   low = 0.1
+   high = 100
+
+   neuron1 = ngpu.Create("aeif_cond_beta_multisynapse", 5000)
+   neuron2 = ngpu.Create("aeif_cond_beta_multisynapse", 5000)
+   ngpu.Connect(neuron1, neuron2, {'rule': 'one_to_one'}, {'delay': {'distribution': 'lognormal_clipped', 'mu': mu, 'sigma':sigma, 'low': low, 'high': high},                   
+                                                         'weight': {'distribution': 'lognormal_clipped', 'mu': mu, 'sigma': sigma, 'low': low, 'high': high}})
+
+
+Other distributions
+-------------------
+
+If other distributions need to be generated, NEST GPU enables
+passing a Python array to the parameter. This way, also the
+distributions implemented in Python scientific libraries can
+be used for simulation. The array can be simply passed when
+setting the node or connection parameter.
+
+


### PR DESCRIPTION
This PR adds two guides to the documentation: one on randomness in NEST GPU (i.e., the description of the rng seed and how to distribute neuron and synapse parameters in NEST GPU) and one describing the current set of kernel parameters.

Fork documentation version available at the following link: https://nest-gpu-fork.readthedocs.io/en/documentation/guides/index.html